### PR TITLE
fix: event fire twice selection

### DIFF
--- a/library/lib/views/cells/cell_selector.cpp
+++ b/library/lib/views/cells/cell_selector.cpp
@@ -28,8 +28,7 @@ SelectorCell::SelectorCell()
     this->registerClickAction([this](View* view) {
         Dropdown* dropdown = new Dropdown(
             this->title->getFullText(), data, [this](int selected) {
-                this->setSelection(selected);
-                this->event.fire(selected);
+                this->setSelection(selected, false);
             },
             selection);
         Application::pushActivity(new Activity(dropdown));


### PR DESCRIPTION
on SelectorCell click selection
event will fire twice