### PR TITLE
fix selectcell dismiss callback

### DIFF
--- a/demo/settings_tab.cpp
+++ b/demo/settings_tab.cpp
@@ -36,7 +36,10 @@ SettingsTab::SettingsTab()
     boolean->title->setText("Switcher");
 
     selector->init("Selector", { "Test 1", "Test 2", "Test 3", "Test 4", "Test 5", "Test 6", "Test 7", "Test 8", "Test 9", "Test 10", "Test 11", "Test 12", "Test 13" }, 0, [](int selected) {
-
+    }, [](int selected) {
+        auto dialog = new brls::Dialog(fmt::format("selected {}", selected));
+        dialog->addButton("hints/ok"_i18n, []() {});
+        dialog->open();
     });
 
     input->init(

--- a/library/include/borealis/views/cells/cell_selector.hpp
+++ b/library/include/borealis/views/cells/cell_selector.hpp
@@ -31,7 +31,7 @@ class SelectorCell : public DetailCell
   public:
     SelectorCell();
 
-    void init(std::string title, std::vector<std::string> data, int selected, Event<int>::Callback callback);
+    void init(std::string title, std::vector<std::string> data, int selected, Event<int>::Callback callback, Event<int>::Callback dismissCb = [](int){});
 
     void setData(std::vector<std::string> data)
     {
@@ -56,6 +56,7 @@ class SelectorCell : public DetailCell
     std::vector<std::string> data;
 
     Event<int> event;
+    Event<int>::Callback dismissCb;
     void updateUI();
 };
 

--- a/library/lib/views/cells/cell_selector.cpp
+++ b/library/lib/views/cells/cell_selector.cpp
@@ -29,18 +29,18 @@ SelectorCell::SelectorCell()
         Dropdown* dropdown = new Dropdown(
             this->title->getFullText(), data, [this](int selected) {
                 this->setSelection(selected, false);
-            },
-            selection);
+            }, selection, this->dismissCb);
         Application::pushActivity(new Activity(dropdown));
         return true;
     });
 }
 
-void SelectorCell::init(std::string title, std::vector<std::string> data, int selected, Event<int>::Callback callback)
+void SelectorCell::init(std::string title, std::vector<std::string> data, int selected, Event<int>::Callback callback, Event<int>::Callback dismissCb)
 {
     this->title->setText(title);
     this->data      = data;
     this->selection = selected;
+    this->dismissCb = dismissCb;
     this->event.subscribe(callback);
     updateUI();
 }


### PR DESCRIPTION
when `brls::Dialog` opened in `brls::SelectorCell` selection event, 
which in `brls::Dropdown::didSelectRowAt`, top Activity (dialog) will pop, and dialog will not show
https://github.com/xfangfang/borealis/blob/wiliwili/library/lib/views/dropdown.cpp#L147

to solve this problem, add `dismissCb` fired after dropdown dismiss

this issue introduced by https://github.com/xfangfang/borealis/pull/24