### PR TITLE
Build map file to make addr2line works better

### DIFF
--- a/library/cmake/commonOption.cmake
+++ b/library/cmake/commonOption.cmake
@@ -57,4 +57,7 @@ endif ()
 
 if (NOT DEFINED APP_PLATFORM_LINK_OPTION)
     set(APP_PLATFORM_LINK_OPTION)
+    if (PLATFORM_SWITCH)
+        list(APPEND APP_PLATFORM_LINK_OPTION "-Wl,-Map,borealis.map")
+    endif ()
 endif ()


### PR DESCRIPTION
This changes will lead to show  line number of source code when using: `aarch64-none-elf-addr2line -e <elf_file> -f -p -C -a <address>`