### PR TITLE
platform/desktop: Fix potential null pointer dereference in getIpAddress

### DIFF
--- a/library/lib/platforms/desktop/desktop_platform.cpp
+++ b/library/lib/platforms/desktop/desktop_platform.cpp
@@ -659,6 +659,7 @@ std::string DesktopPlatform::getIpAddress()
     {
         for (auto addr = interfaces; addr != nullptr; addr = addr->ifa_next)
         {
+            if (!addr->ifa_addr) continue;
             if (addr->ifa_addr->sa_family == AF_INET)
             {
                 ipaddr = inet_ntoa(reinterpret_cast<struct sockaddr_in*>(addr->ifa_addr)->sin_addr);


### PR DESCRIPTION
According to `getifaddrs(3)`:

> The ifa_addr field points to a structure containing the interface address.  (The sa_family subfield should be
> consulted to determine the format of the address structure.)  This field may contain a null pointer.