### PR TITLE
Make brls::Image::setImageFromMem const correct

### DIFF
--- a/library/include/borealis/views/image.hpp
+++ b/library/include/borealis/views/image.hpp
@@ -103,7 +103,7 @@ class Image : public View
      * See Image class documentation for the list of supported
      * image formats.
      */
-    void setImageFromMem(unsigned char* data, int size);
+    void setImageFromMem(const unsigned char* data, int size);
 
     virtual void innerSetImage(int texture);
 

--- a/library/lib/views/image.cpp
+++ b/library/lib/views/image.cpp
@@ -337,12 +337,12 @@ void Image::setImageFromFile(const std::string& path)
     TextureCache::instance().addCache(path, tex);
 }
 
-void Image::setImageFromMem(unsigned char* data, int size)
+void Image::setImageFromMem(const unsigned char* data, int size)
 {
     NVGcontext* vg = Application::getNVGContext();
 
     // Load texture
-    innerSetImage(nvgCreateImageMem(vg, 0, data, size));
+    innerSetImage(nvgCreateImageMem(vg, 0, const_cast<unsigned char*>(data), size));
 }
 
 void Image::setImageAsync(std::function<void(std::function<void(const std::string&, size_t length)>)> cb)


### PR DESCRIPTION
NanoVG is an old C library. Unfortunately, in C libraries, the use of `const` is often absent. This is either because some libraries predate the introduction of the `const` keyword or, most of the time, due to oversights. NanoVG is no exception and, for example, does not use `const` for a buffer in the `nvgCreateImageMem` function 
```
NVGcontext* ctx, int imageFlags, unsigned char* data, int ndata);
```
However, this buffer is used by the 

```
STBIDEF stbi_uc *stbi_load_from_memory (stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels); 
```
function, which indeed expects a "const.".

The purpose of this pull request is to make Borealis const-correct.
Instead of using `const_cast<unsigned char*>(buf)` in the source code of a project using Borealis, it is preferable to use only `buf` and apply `const_cast<unsigned char*>(buf)` directly within the Borealis library.