### PR TITLE
Adding an overload for the function brls::loadTranslations

### DIFF
--- a/library/include/borealis/core/i18n.hpp
+++ b/library/include/borealis/core/i18n.hpp
@@ -84,6 +84,7 @@ std::string getStr(std::string stringName, Args&&... args)
  * Must be called before trying to get a translation!
  */
 void loadTranslations();
+void loadTranslations(const std::string& locale);
 
 inline namespace literals
 {

--- a/library/include/borealis/views/image.hpp
+++ b/library/include/borealis/views/image.hpp
@@ -103,7 +103,7 @@ class Image : public View
      * See Image class documentation for the list of supported
      * image formats.
      */
-    void setImageFromMem(unsigned char* data, int size);
+    void setImageFromMem(const unsigned char* data, int size);
 
     virtual void innerSetImage(int texture);
 

--- a/library/lib/core/i18n.cpp
+++ b/library/lib/core/i18n.cpp
@@ -125,6 +125,12 @@ void loadTranslations()
         loadLocale(currentLocaleName, &currentLocale);
 }
 
+void loadTranslations(const std::string& locale) {
+    loadLocale(LOCALE_DEFAULT, &defaultLocale);
+    if(locale != LOCALE_DEFAULT)
+        loadLocale(locale, &currentLocale);
+}
+
 namespace internal
 {
     std::string getRawStr(std::string stringName)

--- a/library/lib/views/image.cpp
+++ b/library/lib/views/image.cpp
@@ -337,12 +337,12 @@ void Image::setImageFromFile(const std::string& path)
     TextureCache::instance().addCache(path, tex);
 }
 
-void Image::setImageFromMem(unsigned char* data, int size)
+void Image::setImageFromMem(const unsigned char* data, int size)
 {
     NVGcontext* vg = Application::getNVGContext();
 
     // Load texture
-    innerSetImage(nvgCreateImageMem(vg, 0, data, size));
+    innerSetImage(nvgCreateImageMem(vg, 0, const_cast<unsigned char*>(data), size));
 }
 
 void Image::setImageAsync(std::function<void(std::function<void(const std::string&, size_t length)>)> cb)


### PR DESCRIPTION
I wanted to use translations which are not in the nintendo switch system. I added it, it will search in the romfs:/i18n if there is the translation