### PR TITLE
Fix: application might segfault at exit

### DIFF
--- a/library/include/borealis/core/application.hpp
+++ b/library/include/borealis/core/application.hpp
@@ -32,7 +32,6 @@
 #include <borealis/core/view.hpp>
 #include <borealis/views/label.hpp>
 #include <deque>
-#include <unordered_map>
 #include <vector>
 
 #ifdef __WINRT__

--- a/library/include/borealis/core/application.hpp
+++ b/library/include/borealis/core/application.hpp
@@ -31,6 +31,7 @@
 #include <borealis/core/theme.hpp>
 #include <borealis/core/view.hpp>
 #include <borealis/views/label.hpp>
+#include <deque>
 #include <unordered_map>
 #include <vector>
 
@@ -313,7 +314,7 @@ class Application
 
     inline static std::vector<Activity*> activitiesStack;
     inline static std::vector<View*> focusStack;
-    inline static std::set<View*> deletionPool;
+    inline static std::deque<View*> deletionPool;
 
     inline static View* currentFocus = nullptr;
     inline static std::vector<TouchState> currentTouchState;

--- a/library/lib/core/application.cpp
+++ b/library/lib/core/application.cpp
@@ -939,11 +939,10 @@ std::string Application::getLocale()
 
 void Application::addToFreeQueue(View* view)
 {
-    brls::Logger::verbose("Application::addToFreeQueue {}", view->describe());
+    if (std::binary_search(deletionPool.cbegin(), deletionPool.cend(), view))
+        return;
     
-    for (brls::View* viewToDelete : Application::deletionPool)
-        if (viewToDelete == view)
-            return;
+    brls::Logger::verbose("Application::addToFreeQueue {}", view->describe());
 
     Application::deletionPool.push_back(view);
 }

--- a/library/lib/core/view.cpp
+++ b/library/lib/core/view.cpp
@@ -53,8 +53,12 @@ void AppletFrameItem::setHintView(View* hintView)
 
 AppletFrameItem::~AppletFrameItem()
 {
-    if (hintView)
-        delete hintView;
+    if (hintView) {
+        if (!hintView->isPtrLocked())
+            delete hintView;
+        else
+            hintView->freeView();
+    }
 }
 
 View::View()


### PR DESCRIPTION
There is two bugs that sometimes caused a segfault when application exits : 

- The foreach loops on `deletionPool`, when deleting a view, might inserts other views inside the deletionPool set by calling Box destructor, resulting in undefined behavior. To avoid this, the set is can be replaced by a queue. I added required checks in `addToFreeQueue` to avoid queuing the same view twice.
- AppletFrameItem destructor isn't checking if `hintView` is ptr locked before deletion. At application exit it sometimes caused hintView to be deleted twice causing a Segfault.