### PR TITLE
Editable builtin metric values

### DIFF
--- a/library/include/borealis/core/style.hpp
+++ b/library/include/borealis/core/style.hpp
@@ -31,6 +31,7 @@ class StyleValues
     StyleValues(std::initializer_list<std::pair<std::string, float>> list);
 
     void addMetric(std::string name, float value);
+    void setMetric(std::string name, float value);
     float getMetric(std::string name);
 
   private:
@@ -45,6 +46,7 @@ class Style
     float operator[](std::string name);
 
     void addMetric(std::string name, float value);
+    void setMetric(std::string name, float value);
     float getMetric(std::string name);
 
   private:

--- a/library/lib/core/style.cpp
+++ b/library/lib/core/style.cpp
@@ -159,6 +159,14 @@ void StyleValues::addMetric(std::string name, float metric)
     this->values.insert(std::make_pair(name, metric));
 }
 
+void StyleValues::setMetric(std::string name, float value)
+{
+    if (this->values.count(name) == 0)
+        fatal("Unknown style metric \"" + name + "\"");
+
+    this->values.at(name) = value;
+}
+
 float StyleValues::getMetric(std::string name)
 {
     if (this->values.count(name) == 0) {
@@ -182,6 +190,11 @@ float Style::getMetric(std::string name)
 void Style::addMetric(std::string name, float metric)
 {
     return this->values->addMetric(name, metric);
+}
+
+void Style::setMetric(std::string name, float metric)
+{
+    return this->values->setMetric(name, metric);
 }
 
 float Style::operator[](std::string name)


### PR DESCRIPTION
This PR allows library user to changes the default metrics for borealis component, for example: the sidebar width