### PR TITLE
Add a build option to disable highlight animation

### DIFF
--- a/library/cmake/commonOption.cmake
+++ b/library/cmake/commonOption.cmake
@@ -50,6 +50,9 @@ option(USE_GLES3 "using OpenGL ES 3.0" OFF)
 # or if you do not want others to modify the resource files, you can also enable this option
 option(USE_LIBROMFS "using libromfs to bundle resources" OFF)
 
+# Disable highlight border animation (Useful for low-end devices like PSVita)
+option(SIMPLE_HIGHLIGHT "Simple highlight" OFF)
+
 
 if (NOT DEFINED APP_PLATFORM_INCLUDE)
     set(APP_PLATFORM_INCLUDE)

--- a/library/cmake/toolchain.cmake
+++ b/library/cmake/toolchain.cmake
@@ -113,6 +113,11 @@ else ()
     add_definitions(-D__GLFW__)
 endif ()
 
+if (SIMPLE_HIGHLIGHT)
+    message(STATUS "Enable SIMPLE_HIGHLIGHT")
+    add_definitions(-DSIMPLE_HIGHLIGHT)
+endif ()
+
 function(program_target target source)
     if (WIN32 AND NOT WIN32_TERMINAL)
         add_executable(${target} WIN32 ${source})

--- a/library/lib/core/application.cpp
+++ b/library/lib/core/application.cpp
@@ -189,7 +189,9 @@ bool Application::internalMainLoop()
     }
 
     // Animations
+#ifndef SIMPLE_HIGHLIGHT
     updateHighlightAnimation();
+#endif
     Ticking::updateTickings();
 
     // Render
@@ -380,10 +382,10 @@ void Application::processInput()
         if (controllerState.buttons[i])
         {
             repeating = controllerState.repeatingButtonStop[i] > 0 && cpuTime > controllerState.repeatingButtonStop[i];
-            
+
             if (repeating)
                 controllerState.repeatingButtonStop[i] = cpuTime + BUTTON_REPEAT_DELAY;
-            
+
             if (!oldControllerState.buttons[i])
                 controllerState.repeatingButtonStop[i] = cpuTime + BUTTOM_REPEAT_TRIGGER;
 

--- a/library/lib/core/view.cpp
+++ b/library/lib/core/view.cpp
@@ -542,6 +542,14 @@ void View::drawHighlight(NVGcontext* vg, Theme theme, float alpha, Style style, 
     }
     else
     {
+#ifdef SIMPLE_HIGHLIGHT
+        // Border
+        nvgBeginPath(vg);
+        nvgStrokeColor(vg, a(theme["brls/highlight/color1"]));
+        nvgStrokeWidth(vg, style["brls/highlight/stroke_width"]);
+        nvgRoundedRect(vg, x, y, width, height, cornerRadius);
+        nvgStroke(vg);
+#else
         float shadowOffset = style["brls/highlight/shadow_offset"];
 
         // Shadow
@@ -602,6 +610,7 @@ void View::drawHighlight(NVGcontext* vg, Theme theme, float alpha, Style style, 
         nvgStrokeWidth(vg, strokeWidth);
         nvgRoundedRect(vg, x, y, width, height, cornerRadius);
         nvgStroke(vg);
+#endif
     }
 
     nvgRestore(vg);


### PR DESCRIPTION
This is usefull for low-end devices such as PSV, old Android TV...