### PR TITLE
Separate the clear color from the application background

### DIFF
--- a/library/lib/core/application.cpp
+++ b/library/lib/core/application.cpp
@@ -653,7 +653,7 @@ void Application::frame()
     frameContext.theme      = Application::getTheme();
 
     // Begin frame and clear
-    NVGcolor backgroundColor = frameContext.theme["brls/background"];
+    NVGcolor backgroundColor = frameContext.theme["brls/clear"];
     videoContext->beginFrame();
     videoContext->clear(backgroundColor);
     float scaleFactor = videoContext->getScaleFactor();

--- a/library/lib/core/theme.cpp
+++ b/library/lib/core/theme.cpp
@@ -24,6 +24,7 @@ namespace brls
 
 static ThemeValues lightThemeValues = {
     // Generic values
+    { "brls/clear", nvgRGB(235, 235, 235) },
     { "brls/background", nvgRGB(235, 235, 235) },
     { "brls/text", nvgRGB(45, 45, 45) },
     { "brls/text_disabled", nvgRGB(140, 140, 140) },
@@ -82,6 +83,7 @@ static ThemeValues lightThemeValues = {
 
 static ThemeValues darkThemeValues = {
     // Generic values
+    { "brls/clear", nvgRGB(45, 45, 45) },
     { "brls/background", nvgRGB(45, 45, 45) },
     { "brls/text", nvgRGB(255, 255, 255) },
     { "brls/text_disabled", nvgRGB(80, 80, 80) },

--- a/library/lib/platforms/glfw/glfw_video.cpp
+++ b/library/lib/platforms/glfw/glfw_video.cpp
@@ -443,17 +443,17 @@ void GLFWVideoContext::clear(NVGcolor color)
         color.r,
         color.g,
         color.b,
-        1.0f);
+        color.a);
 
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 #elif defined(BOREALIS_USE_METAL)
-    nvgClearWithColor(nvgContext, nvgRGBAf(color.r, color.g, color.b, 1.0f));
+    nvgClearWithColor(nvgContext, nvgRGBAf(color.r, color.g, color.b, color.a));
 #elif defined(BOREALIS_USE_D3D11)
     D3D11_CONTEXT->clear(nvgRGBAf(
         color.r,
         color.g,
         color.b,
-        1.0f));
+        color.a));
 #endif
 }
 

--- a/library/lib/platforms/sdl/sdl_video.cpp
+++ b/library/lib/platforms/sdl/sdl_video.cpp
@@ -354,7 +354,7 @@ void SDLVideoContext::clear(NVGcolor color)
         color.r,
         color.g,
         color.b,
-        1.0f);
+        color.a);
 
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 #elif defined(BOREALIS_USE_D3D11)
@@ -362,7 +362,7 @@ void SDLVideoContext::clear(NVGcolor color)
         color.r,
         color.g,
         color.b,
-        1.0f));
+        color.a));
 #endif
 }
 


### PR DESCRIPTION
Used for Android development:
1. Use`brls::Application::getTheme().addColor("brls/clear", nvgRGBA(0, 0, 0, 0));` to set the Borealis background to transparent.
2. Use `mSurface.getHolder().setFormat(PixelFormat.RGBA_8888);` in the onCreate function of the Android Activity to set the SurfaceView bound to Borealis to allow transparency.

Now you can freely control what can be drawn behind Borealis. In my own application, I use this method to bind ffmpeg to another SurfaceView and place it behind Borealis, instead of directly using OpenGL to draw on Borealis. This reduces copying and greatly improves performance when using hwdec.