### PR TITLE
feat: borealis add unity_build support

### DIFF
--- a/library/include/borealis/core/util.hpp
+++ b/library/include/borealis/core/util.hpp
@@ -21,7 +21,9 @@
 
 namespace brls
 {
+bool endsWith(const std::string& data, const std::string& suffix);
 
+bool startsWith(const std::string& data, const std::string& prefix);
 /**
  * Prints the given error message message and throws a std::logic_error.
  */

--- a/library/include/borealis/views/edit_text_dialog.hpp
+++ b/library/include/borealis/views/edit_text_dialog.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <borealis/core/box.hpp>
 #include <borealis/views/label.hpp>
 #include <borealis/core/bind.hpp>

--- a/library/lib/core/i18n.cpp
+++ b/library/lib/core/i18n.cpp
@@ -38,12 +38,6 @@ namespace brls
 static nlohmann::json defaultLocale = {};
 static nlohmann::json currentLocale = {};
 
-static bool endsWith(const std::string& str, const std::string& suffix)
-{
-    // if I wanted to write my own endsWith I would have made borealis in PHP
-    return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
-}
-
 static void loadLocale(std::string locale, nlohmann::json* target)
 {
     if (locale.empty())

--- a/library/lib/core/util.cpp
+++ b/library/lib/core/util.cpp
@@ -20,6 +20,16 @@
 namespace brls
 {
 
+bool endsWith(const std::string& data, const std::string& suffix)
+{
+    return data.find(suffix, data.size() - suffix.size()) != std::string::npos;
+}
+
+bool startsWith(const std::string& data, const std::string& prefix)
+{
+    return data.rfind(prefix, 0) == 0;
+}
+
 [[noreturn]] void fatal(std::string message)
 {
     brls::Logger::error("Fatal error: {}", message);

--- a/library/lib/core/view.cpp
+++ b/library/lib/core/view.cpp
@@ -35,16 +35,6 @@ using namespace brls::literals;
 namespace brls
 {
 
-static bool endsWith(const std::string& data, const std::string& suffix)
-{
-    return data.find(suffix, data.size() - suffix.size()) != std::string::npos;
-}
-
-static bool startsWith(const std::string& data, const std::string& prefix)
-{
-    return data.rfind(prefix, 0) == 0;
-}
-
 void AppletFrameItem::setHintView(View* hintView)
 {
     this->hintView = hintView;

--- a/xmake.lua
+++ b/xmake.lua
@@ -108,6 +108,12 @@ target("borealis")
     end
     add_packages("tinyxml2", "nlohmann_json", "nanovg", "fmt", "tweeny", "yoga", "stb")
     add_defines("BOREALIS_USE_STD_THREAD")
+    if is_plat("macosx") then
+        add_frameworks("SystemConfiguration", "CoreWlan")
+        add_files("library/lib/platforms/desktop/desktop_darwin.mm")
+    end
+    add_rules("c++.unity_build", {batchsize = 16})
+    add_rules("c.unity_build", {batchsize = 16})
 
 
 target("demo")
@@ -152,3 +158,4 @@ target("demo")
         end
     end
     set_rundir("$(projectdir)")
+    add_rules("c++.unity_build", {batchsize = 16})


### PR DESCRIPTION
使用 xmake 的 unity_build 的编译选项，全量不包含外部依赖在我的黑苹果从 160s 降到 60s。
未使用 unity_build
```sh
> rm -rf ./build
> time xmake b demo
checking for Xcode directory ... /Applications/Xcode.app
checking for Codesign Identity of Xcode ... Apple Development: 390720046@qq.com (52L3LRH9JV)
checking for SDK version of Xcode for macosx (x86_64) ... 12.3
checking for Minimal target version of Xcode for macosx (x86_64) ... 12.3
……
[ 94%]: archiving.release libborealis.a
[ 97%]: linking.release demo
[100%]: build ok, spent 25.658s

________________________________________________________
Executed in   27.97 secs    fish           external
   usr time  160.29 secs  102.00 micros  160.29 secs
   sys time    7.98 secs  727.00 micros    7.97 secs
```

使用 unity_build
```sh
> rm -rf ./build
> time xmake b demo
checking for Xcode directory ... /Applications/Xcode.app
checking for Codesign Identity of Xcode ... Apple Development: 390720046@qq.com (52L3LRH9JV)
checking for SDK version of Xcode for macosx (x86_64) ... 12.3
checking for Minimal target version of Xcode for macosx (x86_64) ... 12.3
[ 15%]: cache compiling.release build/.gens/borealis/macosx/unity_build/unity_1.c
[ 15%]: cache compiling.release build/.gens/borealis/macosx/unity_build/unity_1.cpp
[ 15%]: cache compiling.release library/lib/platforms/desktop/desktop_darwin.mm
[ 15%]: cache compiling.release build/.gens/borealis/macosx/unity_build/unity_2.cpp
[ 15%]: cache compiling.release build/.gens/borealis/macosx/unity_build/unity_3.cpp
[ 15%]: cache compiling.release build/.gens/borealis/macosx/unity_build/unity_4.cpp
[ 15%]: cache compiling.release build/.gens/demo/macosx/unity_build/unity_1.cpp
In file included from build/.gens/borealis/macosx/unity_build/unity_3.cpp:10:
build/.gens/borealis/macosx/unity_build/../../../../../library/lib/views/h_scrolling_frame.cpp:583:9: warning: 'NO_PADDING' macro redefined [-Wmacro-redefined]
#define NO_PADDING fatal("Padding is not supported by brls:HScrollingFrame, please set padding on the content view instead");
        ^
build/.gens/borealis/macosx/unity_build/../../../../../library/lib/views/scrolling_frame.cpp:584:9: note: previous definition is here
#define NO_PADDING fatal("Padding is not supported by brls:ScrollingFrame, please set padding on the content view instead");
        ^
1 warning generated.
[ 69%]: archiving.release libborealis.a
[ 84%]: linking.release demo
[100%]: build ok, spent 20.645s

________________________________________________________
Executed in   22.98 secs    fish           external
   usr time   60.12 secs   99.00 micros   60.12 secs
   sys time    2.13 secs  599.00 micros    2.13 secs
```