### PR TITLE
views: add ProgressDisplay view 

### DIFF
--- a/demo/progress_view.cpp
+++ b/demo/progress_view.cpp
@@ -9,6 +9,10 @@ ProgressBarView::ProgressBarView() {
     this->label->setText("Loading...");
     this->label->setParent(this);
 
+    this->setFocusable(true);
+    this->setHideHighlightBackground(true);
+    this->setHideHighlightBorder(true);
+
     this->registerAction("back", brls::ControllerButton::BUTTON_B, [this](brls::View* view) {
         this->dismiss();
         return true;
@@ -16,8 +20,6 @@ ProgressBarView::ProgressBarView() {
 
     // Démarrer la tâche de chargement
     std::thread loadingThread([this]() {
-        auto start = std::chrono::steady_clock::now();
-
         while (this->progressValue < 1000) {
             this->progressValue += 10;
             brls::sync([this]() { updateProgressOnMainThread(progressValue); }); // Mettre à jour la progression sur le thread principal

--- a/demo/progress_view.cpp
+++ b/demo/progress_view.cpp
@@ -1,0 +1,46 @@
+#include "progress_view.hpp"
+#include <chrono>
+
+ProgressBarView::ProgressBarView() {
+    this->inflateFromXMLRes("xml/views/progress.xml");
+
+    this->progress->setProgress(this->progressValue, 1000);
+    this->progress->setParent(this);
+    this->label->setText("Loading...");
+    this->label->setParent(this);
+
+    this->registerAction("back", brls::ControllerButton::BUTTON_B, [this](brls::View* view) {
+        this->dismiss();
+        return true;
+    });
+
+    // Démarrer la tâche de chargement
+    std::thread loadingThread([this]() {
+        auto start = std::chrono::steady_clock::now();
+
+        while (this->progressValue < 1000) {
+            this->progressValue += 10;
+            brls::sync([this]() { updateProgressOnMainThread(progressValue); }); // Mettre à jour la progression sur le thread principal
+            std::this_thread::sleep_for(std::chrono::milliseconds(50)); // Attendre 500 millisecondes entre chaque mise à jour
+        }
+
+        brls::sync([this]() { finishLoadingOnMainThread(); }); // Signaler la fin du chargement sur le thread principal
+    });
+
+    loadingThread.detach();
+}
+
+void ProgressBarView::updateProgressOnMainThread(int value) {
+    this->progress->setProgress(value, 1000);
+    this->label->setText("Loading... " + std::to_string(value / 10) + "%");
+}
+
+void ProgressBarView::finishLoadingOnMainThread() {
+    this->progressValue = 1000;
+    this->progress->setProgress(progressValue, 1000);
+    this->label->setText("Loading... 100%");
+}
+
+brls::View* ProgressBarView::create() {
+    return new ProgressBarView();
+}

--- a/demo/progress_view.hpp
+++ b/demo/progress_view.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <borealis.hpp>
+
+class ProgressBarView : public brls::Box {
+    public:
+        ProgressBarView();
+
+        static brls::View* create();
+    private:
+        BRLS_BIND(brls::ProgressDisplay, progress, "progress");
+        BRLS_BIND(brls::Label, label, "label");
+        int progressValue = 0;
+
+        void updateProgressOnMainThread(int value);
+        void finishLoadingOnMainThread();
+};

--- a/demo/progress_view.hpp
+++ b/demo/progress_view.hpp
@@ -14,4 +14,6 @@ class ProgressBarView : public brls::Box {
 
         void updateProgressOnMainThread(int value);
         void finishLoadingOnMainThread();
+
+        bool stopThread = false;
 };

--- a/demo/settings_tab.cpp
+++ b/demo/settings_tab.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "settings_tab.hpp"
+#include "progress_view.hpp"
 
 using namespace brls::literals;  // for _i18n
 
@@ -30,6 +31,13 @@ SettingsTab::SettingsTab()
     radio->registerClickAction([this](brls::View* view) {
         radioSelected = !radioSelected;
         this->radio->setSelected(radioSelected);
+        return true;
+    });
+
+    progress->title->setText("Progress cell");
+    progress->setSelected(false);
+    progress->registerClickAction([this](brls::View* view) {
+        this->present(new ProgressBarView());
         return true;
     });
 
@@ -57,6 +65,7 @@ SettingsTab::SettingsTab()
     fps->init("FPS", brls::Application::getFPSStatus(), [](bool value){
         brls::Application::setFPSStatus(value);
     });
+
 
     selector->init("Selector", { "Test 1", "Test 2", "Test 3", "Test 4", "Test 5", "Test 6", "Test 7", "Test 8", "Test 9", "Test 10", "Test 11", "Test 12", "Test 13" }, 0, [](int selected) {
     }, [](int selected) {

--- a/demo/settings_tab.hpp
+++ b/demo/settings_tab.hpp
@@ -33,6 +33,7 @@ class SettingsTab : public brls::Box
     BRLS_BIND(brls::BooleanCell, debug, "debug");
     BRLS_BIND(brls::BooleanCell, bottomBar, "bottomBar");
     BRLS_BIND(brls::BooleanCell, fps, "fps");
+    BRLS_BIND(brls::RadioCell, progress, "progress");
     BRLS_BIND(brls::SliderCell, slider, "slider");
 
     static brls::View* create();

--- a/library/include/borealis.hpp
+++ b/library/include/borealis.hpp
@@ -53,6 +53,7 @@
 #include <borealis/views/image.hpp>
 #include <borealis/views/label.hpp>
 #include <borealis/views/progress_spinner.hpp>
+#include <borealis/views/progress_display.hpp>
 #include <borealis/views/rectangle.hpp>
 #include <borealis/views/recycler.hpp>
 #include <borealis/views/scrolling_frame.hpp>

--- a/library/include/borealis/views/progress_display.hpp
+++ b/library/include/borealis/views/progress_display.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <borealis/core/view.hpp>
+#include <borealis/views/label.hpp>
+#include <borealis/views/progress_spinner.hpp>
+
+namespace brls {
+
+// A progress bar with an optional spinner and percentage text.
+class ProgressDisplay : public View {
+    public:
+        ProgressDisplay();
+
+        void draw(NVGcontext* vg, float x, float y, float width, float height, Style style, FrameContext* ctx) override;
+        void willAppear(bool resetState = false) override;
+        void willDisappear(bool resetState = false) override;    
+
+        void setProgress(int current, int max);
+        void setProgress(float current, float max);
+
+        static brls::View* create();
+    private:
+        float progressPercentage = 0.0f;
+};
+
+} // namespace brls

--- a/library/lib/core/application.cpp
+++ b/library/lib/core/application.cpp
@@ -40,6 +40,7 @@
 #include <borealis/views/hint.hpp>
 #include <borealis/views/image.hpp>
 #include <borealis/views/progress_spinner.hpp>
+#include <borealis/views/progress_display.hpp>
 #include <borealis/views/rectangle.hpp>
 #include <borealis/views/recycler.hpp>
 #include <borealis/views/sidebar.hpp>
@@ -1204,6 +1205,7 @@ void Application::registerBuiltInXMLViews()
     Application::registerXMLView("brls:Slider", Slider::create);
     Application::registerXMLView("brls:BottomBar", BottomBar::create);
     Application::registerXMLView("brls:ProgressSpinner", ProgressSpinner::create);
+    Application::registerXMLView("brls:ProgressDisplay", ProgressDisplay::create);
 
     // Cells
     Application::registerXMLView("brls:DetailCell", DetailCell::create);

--- a/library/lib/core/theme.cpp
+++ b/library/lib/core/theme.cpp
@@ -79,6 +79,10 @@ static ThemeValues lightThemeValues = {
     // Spinner
     { "brls/spinner/bar_color", nvgRGBA(131, 131, 131, 80) },
 
+    // Progress bar
+    { "brls/progress_bar/empty_bar_color", nvgRGB(207, 207, 207) },
+    { "brls/progress_bar/bar_color", nvgRGB(43, 81, 226) },
+
 };
 
 static ThemeValues darkThemeValues = {
@@ -137,6 +141,10 @@ static ThemeValues darkThemeValues = {
 
     // Spinner
     { "brls/spinner/bar_color", nvgRGBA(192, 192, 192, 80) }, // TODO: get this right
+
+    // Progress bar
+    { "brls/progress_bar/empty_bar_color", nvgRGB(78, 78, 78) },
+    { "brls/progress_bar/bar_color", nvgRGB(88, 195, 169) },
 };
 
 ThemeValues::ThemeValues(std::initializer_list<std::pair<std::string, NVGcolor>> list)

--- a/library/lib/views/progress_display.cpp
+++ b/library/lib/views/progress_display.cpp
@@ -1,0 +1,69 @@
+#include <borealis/core/application.hpp>
+#include <borealis/views/progress_display.hpp>
+
+namespace brls
+{
+
+ProgressDisplay::ProgressDisplay()
+{
+
+}
+
+void ProgressDisplay::setProgress(int current, int max) {
+    if(current > max) return;
+
+    this->progressPercentage = ((current * 100) / max);
+}
+
+
+void ProgressDisplay::setProgress(float current, float max)
+{
+    if (current > max) return;
+
+    this->progressPercentage = ((current * 100) / max);
+}
+
+void ProgressDisplay::draw(NVGcontext* vg, float x, float y, float width, float height, Style style, FrameContext* ctx)
+{
+    height = 50.f;
+
+    Theme theme       = Application::getTheme();
+    NVGcolor emptyBarColor = a(theme["brls/progress_bar/empty_bar_color"]);
+    NVGcolor barColor = a(theme["brls/progress_bar/bar_color"]);
+
+    // progressBarX = 600;
+    // progressBarWidth = 400;
+
+    nvgBeginPath(vg);
+    nvgMoveTo(vg, x, y + height / 2);
+    nvgLineTo(vg, x + width, y + height / 2);
+    nvgStrokeColor(vg, emptyBarColor);
+    nvgStrokeWidth(vg, height / 3);
+    nvgLineCap(vg, NVG_ROUND);
+    nvgStroke(vg);
+
+    if(this->progressPercentage > 0.0f) {
+        nvgBeginPath(vg);
+        nvgMoveTo(vg, x, y + height / 2);
+        nvgLineTo(vg, x + ((float)width * this->progressPercentage) / 100, y + height / 2);
+        nvgStrokeColor(vg, barColor);
+        nvgStrokeWidth(vg, height / 3);
+        nvgLineCap(vg, NVG_ROUND);
+        nvgStroke(vg);
+    }
+}
+
+void ProgressDisplay::willAppear(bool resetState) {
+
+}
+
+void ProgressDisplay::willDisappear(bool resetState) {
+
+}
+
+brls::View* ProgressDisplay::create() {
+    return new ProgressDisplay();
+
+}
+
+} // namespace brls

--- a/library/lib/views/progress_display.cpp
+++ b/library/lib/views/progress_display.cpp
@@ -31,9 +31,6 @@ void ProgressDisplay::draw(NVGcontext* vg, float x, float y, float width, float 
     NVGcolor emptyBarColor = a(theme["brls/progress_bar/empty_bar_color"]);
     NVGcolor barColor = a(theme["brls/progress_bar/bar_color"]);
 
-    // progressBarX = 600;
-    // progressBarWidth = 400;
-
     nvgBeginPath(vg);
     nvgMoveTo(vg, x, y + height / 2);
     nvgLineTo(vg, x + width, y + height / 2);

--- a/resources/xml/tabs/settings.xml
+++ b/resources/xml/tabs/settings.xml
@@ -53,7 +53,10 @@
                 id="fps"/>
 
             <brls:SliderCell
-                    id="slider"/>
+                id="slider"/>
+
+            <brls:RadioCell 
+                id="progress"/>
 
             <brls:RadioCell/>
             <brls:RadioCell/>

--- a/resources/xml/views/progress.xml
+++ b/resources/xml/views/progress.xml
@@ -1,0 +1,24 @@
+<brls:Box
+    width="auto"
+    height="auto"
+    axis="column"
+    alignItems="center"
+    paddingTop="50px"
+    paddingBottom="50px"
+    paddingLeft="75px"
+    paddingRight="75px">
+
+    <brls:Label
+        id="label"
+        height="auto"
+        width="40%"
+        grow="1.0"
+        horizontalAlign="center"/>
+
+    <brls:ProgressDisplay
+        id="progress"
+        width="80%"
+        height="50px"
+        grow="1.0"/>
+
+</brls:Box>


### PR DESCRIPTION
Just made a new view based on an older version of borealis.

I have a small issue, I don't know how to manipulate the [height](https://github.com/xfangfang/borealis/compare/wiliwili...PoloNX:progress?expand=1#diff-ea89920cbf8f673e5013f8e4ff79415d72b02a5eb9ff59bb7cf2c746135ed43cR28)  

If I change it in the [.xml ](resources/xml/views/progress.xml) it doesn't change the value of the `height` value. I fixed it to 50 which is good but I think it's not very reliable

![image](https://github.com/xfangfang/borealis/assets/57038157/74b71b34-8bdc-46f9-bf25-752b8feee61d)
