### PR TITLE
Thread safe logging

### DIFF
--- a/library/include/borealis/core/logger.hpp
+++ b/library/include/borealis/core/logger.hpp
@@ -163,7 +163,7 @@ class Logger
 
   private:
     inline static std::mutex logMtx;
-    inline static bool threadSafeLogging = false;
+    inline static bool threadSafeLogging = true;
     inline static Event<TimePoint, LogLevel, std::string> logEvent;
     inline static std::FILE *logOut = stdout;
     inline static LogLevel logLevel = LogLevel::LOG_INFO;

--- a/library/lib/core/logger.cpp
+++ b/library/lib/core/logger.cpp
@@ -33,4 +33,8 @@ void Logger::setLogOutput(std::FILE *newLogOut)
     Logger::logOut = newLogOut;
 }
 
+void Logger::setThreadSafeLogging(bool newThreadSafeLogging) {
+    Logger::threadSafeLogging = newThreadSafeLogging;
+}
+
 } // namespace brls


### PR DESCRIPTION
This PR adds `Logger::setThreadSafeLogging(bool)` and if `true` is passed the logging methods will lock a mutex before printing to `logOutput` and firing `logEvent`