### PR TITLE
PanGestureRecognizer jittering fix

### DIFF
--- a/library/lib/core/touch/pan_gesture.cpp
+++ b/library/lib/core/touch/pan_gesture.cpp
@@ -98,14 +98,22 @@ GestureState PanGestureRecognizer::recognitionLoop(TouchState touch, MouseState 
                     switch (axis)
                     {
                         case PanAxis::HORIZONTAL:
-                            if (fabs(delta.x) > fabs(delta.y))
+                            if (fabs(delta.x) > fabs(delta.y)) {
+                                this->delta = Point();
+                                this->startPosition = position;
                                 this->state = GestureState::START;
+                            }
                             break;
                         case PanAxis::VERTICAL:
-                            if (fabs(delta.x) < fabs(delta.y))
+                            if (fabs(delta.x) < fabs(delta.y)) {
+                                this->delta = Point();
+                                this->startPosition = position;
                                 this->state = GestureState::START;
+                            }
                             break;
                         case PanAxis::ANY:
+                            this->delta = Point();
+                            this->startPosition = position;
                             this->state = GestureState::START;
                             break;
                     }


### PR DESCRIPTION
Because pan recognizer needs some threshold to consider itself as "Recognised", after it change the status to "START" view scrolled by this gesture will jump on this threshold value, because startPoint was set when gesture was in "UNSURE" state and delta will not be zero, so I reset starting point and delta when state changes to "START" to avoid this "jumping" effect