### PR TITLE
Workaround fix for wlan level under win11 24h2 when disable location access

### DIFF
--- a/library/lib/platforms/desktop/desktop_platform.cpp
+++ b/library/lib/platforms/desktop/desktop_platform.cpp
@@ -124,6 +124,7 @@ int win32_wlan_quality()
                     WlanFreeMemory(attrs);
                     break;
                 }
+                quality = 100;
             }
             WlanFreeMemory(ppinfo);
         }


### PR DESCRIPTION
refer https://learn.microsoft.com/en-us/windows/win32/nativewifi/wi-fi-access-location-changes