### PR TITLE
Fix Box navigation after removing child View

### DIFF
--- a/library/lib/core/box.cpp
+++ b/library/lib/core/box.cpp
@@ -220,6 +220,14 @@ void Box::removeView(View* view, bool free)
         YGNodeRemoveChild(this->ygNode, view->getYGNode());
     this->children.erase(this->children.begin() + index);
 
+    // Update parent userdata
+    for (size_t i = index; i < this->children.size(); i++)
+    {
+        auto* index = (size_t*)this->children[i]->getParentUserData();
+        if (index)
+            (*index)--;
+    }
+
     view->willDisappear(true);
     if (free)
         view->freeView();


### PR DESCRIPTION
UserData of child views was unmodified after removing any of Box child view, which causes issues with navigation in this Box