### PR TITLE
Implemented Screenshot and Home buttons custom events

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -262,7 +262,7 @@ message(STATUS "borealis driver ${BOREALIS_DRIVER}")
 # borealis Library
 add_library(borealis STATIC ${BOREALIS_SRC})
 set_target_properties(borealis PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         UNITY_BUILD ${BRLS_UNITY_BUILD}
 )
 set_source_files_properties(${BOREALIS_PATH}/lib/platforms/desktop/desktop_darwin.mm PROPERTIES

--- a/library/include/borealis/core/util.hpp
+++ b/library/include/borealis/core/util.hpp
@@ -31,4 +31,30 @@ bool startsWith(const std::string& data, const std::string& prefix);
 
 std::string loadFileContents(const std::string& path);
 
+#define _BR_CAT(x, y) x ## y
+#define  BR_CAT(x, y) _BR_CAT(x, y)
+#define BR_ANONYMOUS BR_CAT(var, __COUNTER__)
+#define DEFER(f) auto BR_ANONYMOUS = ::brls::_Defer(f)
+
+template <typename F>
+struct _Defer {
+    [[nodiscard]] _Defer(F &&f): f(std::move(f)) { }
+
+    _Defer(const _Defer &) = delete;
+    _Defer &operator =(const _Defer &) = delete;
+
+    ~_Defer() {
+        if (this->want_run)
+            this->f();
+    }
+
+    void cancel() {
+        this->want_run = false;
+    }
+
+    private:
+        bool want_run = true;
+        F f;
+};
+
 } // namespace brls

--- a/library/include/borealis/core/util.hpp
+++ b/library/include/borealis/core/util.hpp
@@ -31,10 +31,12 @@ bool startsWith(const std::string& data, const std::string& prefix);
 
 std::string loadFileContents(const std::string& path);
 
+namespace utils {
+
 #define _BR_CAT(x, y) x ## y
 #define  BR_CAT(x, y) _BR_CAT(x, y)
 #define BR_ANONYMOUS BR_CAT(var, __COUNTER__)
-#define DEFER(f) auto BR_ANONYMOUS = ::brls::_Defer(f)
+#define DEFER(f) auto BR_ANONYMOUS = ::brls::utils::_Defer(f)
 
 template <typename F>
 struct _Defer {
@@ -57,4 +59,5 @@ struct _Defer {
         F f;
 };
 
+} // namespace utils
 } // namespace brls

--- a/library/include/borealis/platforms/switch/switch_input.hpp
+++ b/library/include/borealis/platforms/switch/switch_input.hpp
@@ -28,6 +28,12 @@
 namespace brls
 {
 
+enum class ButtonOverrideMode {
+    NONE,
+    CUSTOM_EVENT,
+    GUIDE_BUTTON
+};
+
 // InputManager that uses the hid sysmodule to get inputs
 class SwitchInputManager : public InputManager
 {
@@ -59,16 +65,33 @@ class SwitchInputManager : public InputManager
 
     void clearVibration(int controller);
 
-    bool isReplaceScreenshotWithGuideButton() { return replaceScreenshotWithGuideButton; }
-    void setReplaceScreenshotWithGuideButton(bool value) { replaceScreenshotWithGuideButton = value; }
+    /*
+    * It will not report about screenshot button state, if screenshotButtonOverrideMode equals NONE
+    */
+    bool isScreenshotButtonPressed() { return m_isScreenshotPressed; }
+
+    /*
+    * It will not report about home button state, if homeButtonOverrideMode equals NONE
+    */
+    bool isHomeButtonPressed() { return m_isHomePressed; }
+
+    ButtonOverrideMode screenshotButtonOverrideMode() { return m_screenshotButtonMode; }
+    void setScreenshotButtonOverrideMode(ButtonOverrideMode value) { m_screenshotButtonMode = value; }
+
+    ButtonOverrideMode homeButtonOverrideMode() { return m_homeButtonMode; }
+    void setHomeButtonOverrideMode(ButtonOverrideMode value) { m_homeButtonMode = value; }
 
   private:
     void screenshot_button_thread_fn(std::stop_token token);
-    bool replaceScreenshotWithGuideButton = false;
     std::jthread screenshot_button_thread;
 
+    ButtonOverrideMode m_screenshotButtonMode = ButtonOverrideMode::NONE;
+    ButtonOverrideMode m_homeButtonMode = ButtonOverrideMode::NONE;
+
   private:
-    bool isScreenshotPressed = false;
+    bool m_isScreenshotPressed = false;
+    bool m_isHomePressed = false;
+
     bool cursorInited = false;
     int cursorWidth, cursorHeight;
     int cursorTexture = 0;

--- a/library/include/borealis/platforms/switch/switch_input.hpp
+++ b/library/include/borealis/platforms/switch/switch_input.hpp
@@ -19,6 +19,8 @@
 
 #include <switch.h>
 
+#include <stop_token>
+#include <thread>
 #include <borealis/core/input.hpp>
 
 #define TOUCHES_MAX 10
@@ -57,7 +59,16 @@ class SwitchInputManager : public InputManager
 
     void clearVibration(int controller);
 
+    bool isReplaceScreenshotWithGuideButton() { return replaceScreenshotWithGuideButton; }
+    void setReplaceScreenshotWithGuideButton(bool value) { replaceScreenshotWithGuideButton = value; }
+
   private:
+    void screenshot_button_thread_fn(std::stop_token token);
+    bool replaceScreenshotWithGuideButton = false;
+    std::jthread screenshot_button_thread;
+
+  private:
+    bool isScreenshotPressed = false;
     bool cursorInited = false;
     int cursorWidth, cursorHeight;
     int cursorTexture = 0;

--- a/library/include/borealis/platforms/switch/switch_video.hpp
+++ b/library/include/borealis/platforms/switch/switch_video.hpp
@@ -31,7 +31,7 @@ typedef Event _LibNXEvent; // "Event" alone clashes with brls::Event
 namespace brls
 {
 
-static constexpr const unsigned FRAMEBUFFERS_COUNT = 2;
+static constexpr const unsigned FRAMEBUFFERS_COUNT = 3;
 
 // deko3d video context
 class SwitchVideoContext : public VideoContext

--- a/library/lib/platforms/switch/switch_input.cpp
+++ b/library/lib/platforms/switch/switch_input.cpp
@@ -18,6 +18,7 @@
 #include <borealis/core/thread.hpp>
 #include <borealis/core/application.hpp>
 #include <borealis/platforms/switch/switch_input.hpp>
+#include <borealis/core/application.hpp>
 
 // Avoid namespace collision
 #define NXEvent ::Event
@@ -236,8 +237,13 @@ void SwitchInputManager::updateControllerStateInner(ControllerState* state, PadS
         state->buttons[i]  = keysDown & switchKey;
     }
 
-    if (replaceScreenshotWithGuideButton)
-        state->buttons[BUTTON_GUIDE] = isScreenshotPressed;
+    state->buttons[BUTTON_GUIDE] = false;
+
+    if (m_screenshotButtonMode == ButtonOverrideMode::GUIDE_BUTTON)
+        state->buttons[BUTTON_GUIDE] |= m_isScreenshotPressed;
+
+    if (m_homeButtonMode == ButtonOverrideMode::GUIDE_BUTTON)
+        state->buttons[BUTTON_GUIDE] |= m_isHomePressed;
 
     HidAnalogStickState analog_stick_l = padGetStickPos(pad, 0);
     HidAnalogStickState analog_stick_r = padGetStickPos(pad, 1);
@@ -639,48 +645,62 @@ void SwitchInputManager::screenshot_button_thread_fn(std::stop_token token) {
         return;
     }
 
-    NXEvent activity_evt;
-    DEFER([&activity_evt] { eventClose(&activity_evt); });
-    if (auto rc = inssGetWritableEvent(0, &activity_evt); R_FAILED(rc)) {
-        Logger::error("Failed to acquire the activity event: {}\n", rc);
+    NXEvent home_evt;
+    DEFER([&home_evt] { eventClose(&home_evt); });
+    if (auto rc = hidsysAcquireHomeButtonEventHandle(&home_evt, false); R_FAILED(rc)) {
+        Logger::error("Failed to acquire the home button event: {}\n", rc);
         return;
     }
 
-    UTimer activity_timer;
-    DEFER([&activity_timer] { utimerStop(&activity_timer); });
-
-    utimerCreate(&activity_timer, std::chrono::nanoseconds(500ms).count(), TimerType_Repeating);
-    utimerStart(&activity_timer);
-
     eventClear(&screenshot_evt);
+    eventClear(&home_evt);
 
-    u64 down_start_tick = 0;
+    u64 screenshot_down_start_tick = 0;
+    u64 home_down_start_tick = 0;
+
     while (!token.stop_requested()) {
         s32 idx;
         auto rc = waitMulti(&idx, std::chrono::nanoseconds(50ms).count(),
-            waiterForEvent(&screenshot_evt), waiterForUTimer(&activity_timer));
-
-        if (!this->replaceScreenshotWithGuideButton)
-            continue;
+            waiterForEvent(&screenshot_evt), waiterForEvent(&home_evt));
 
         if (rc == KERNELRESULT(TimedOut))
             continue;
 
         switch (idx) {
             case 0: // Screenshot button
-                if (!this->replaceScreenshotWithGuideButton)
+                if (this->m_screenshotButtonMode == ButtonOverrideMode::NONE) {
+                    m_isScreenshotPressed = false;
                     break;
+                }
 
                 eventClear(&screenshot_evt);
 
-                if (!down_start_tick) {
-                    down_start_tick = armGetSystemTick();
-                    isScreenshotPressed = true;
+                if (!screenshot_down_start_tick) {
+                    screenshot_down_start_tick = armGetSystemTick();
+                    m_isScreenshotPressed = true;
                     Logger::info("Screenshot button clicked");
                 } else {
-                    down_start_tick    = 0;
-                    isScreenshotPressed = false;
+                    screenshot_down_start_tick    = 0;
+                    m_isScreenshotPressed = false;
                     Logger::info("Screenshot button released");
+                }
+                break;
+            case 1: // Home button
+                if (this->m_homeButtonMode == ButtonOverrideMode::NONE) {
+                    m_isHomePressed = false;
+                    break;
+                }
+            
+                eventClear(&home_evt);
+
+                if (!home_down_start_tick) {
+                    home_down_start_tick = armGetSystemTick();
+                    m_isHomePressed = true;
+                    Logger::info("Home button clicked");
+                } else {
+                    home_down_start_tick    = 0;
+                    m_isHomePressed = false;
+                    Logger::info("Home button released");
                 }
                 break;
             default:

--- a/library/lib/platforms/switch/switch_input.cpp
+++ b/library/lib/platforms/switch/switch_input.cpp
@@ -14,8 +14,15 @@
     limitations under the License.
 */
 
+#include <chrono>
+#include <borealis/core/thread.hpp>
 #include <borealis/core/application.hpp>
 #include <borealis/platforms/switch/switch_input.hpp>
+
+// Avoid namespace collision
+#define NXEvent ::Event
+
+using namespace std::chrono_literals;
 
 namespace brls
 {
@@ -98,6 +105,8 @@ static const size_t SWITCH_AXIS_MAPPING[_AXES_MAX] = {
 
 SwitchInputManager::SwitchInputManager()
 {
+    this->screenshot_button_thread = std::jthread(&SwitchInputManager::screenshot_button_thread_fn, this);
+
     padConfigureInput(GAMEPADS_MAX, HidNpadStyleSet_NpadStandard);
     hidSetNpadJoyHoldType(HidNpadJoyHoldType_Horizontal);
     hidSetNpadHandheldActivationMode(HidNpadHandheldActivationMode_Single);
@@ -131,6 +140,7 @@ SwitchInputManager::SwitchInputManager()
 
 SwitchInputManager::~SwitchInputManager()
 {
+    this->screenshot_button_thread.request_stop();
     NVGcontext* vg = Application::getNVGContext();
 
     if (this->cursorTexture != 0)
@@ -225,6 +235,9 @@ void SwitchInputManager::updateControllerStateInner(ControllerState* state, PadS
         uint64_t switchKey = full ? SWITCH_BUTTONS_FULL_MAPPING[i] : SWITCH_BUTTONS_HALF_MAPPING[i];
         state->buttons[i]  = keysDown & switchKey;
     }
+
+    if (replaceScreenshotWithGuideButton)
+        state->buttons[BUTTON_GUIDE] = isScreenshotPressed;
 
     HidAnalogStickState analog_stick_l = padGetStickPos(pad, 0);
     HidAnalogStickState analog_stick_r = padGetStickPos(pad, 1);
@@ -612,6 +625,67 @@ BrlsKeyboardScancode SwitchInputManager::switchKeyToGlfwKey(int key)
         // case KBD_HASHTILDE: return GLFW_HASHTILDE;
         default:
             return BRLS_KBD_KEY_UNKNOWN;
+    }
+}
+
+void SwitchInputManager::screenshot_button_thread_fn(std::stop_token token) {
+    // This needs a high priority because we are racing am to clear the event
+    svcSetThreadPriority(CUR_THREAD_HANDLE, 0x20);
+
+    NXEvent screenshot_evt;
+    DEFER([&screenshot_evt] { eventClose(&screenshot_evt); });
+    if (auto rc = hidsysAcquireCaptureButtonEventHandle(&screenshot_evt, false); R_FAILED(rc)) {
+        Logger::error("Failed to acquire the screenshot button event: {}\n", rc);
+        return;
+    }
+
+    NXEvent activity_evt;
+    DEFER([&activity_evt] { eventClose(&activity_evt); });
+    if (auto rc = inssGetWritableEvent(0, &activity_evt); R_FAILED(rc)) {
+        Logger::error("Failed to acquire the activity event: {}\n", rc);
+        return;
+    }
+
+    UTimer activity_timer;
+    DEFER([&activity_timer] { utimerStop(&activity_timer); });
+
+    utimerCreate(&activity_timer, std::chrono::nanoseconds(500ms).count(), TimerType_Repeating);
+    utimerStart(&activity_timer);
+
+    eventClear(&screenshot_evt);
+
+    u64 down_start_tick = 0;
+    while (!token.stop_requested()) {
+        s32 idx;
+        auto rc = waitMulti(&idx, std::chrono::nanoseconds(50ms).count(),
+            waiterForEvent(&screenshot_evt), waiterForUTimer(&activity_timer));
+
+        if (!this->replaceScreenshotWithGuideButton)
+            continue;
+
+        if (rc == KERNELRESULT(TimedOut))
+            continue;
+
+        switch (idx) {
+            case 0: // Screenshot button
+                if (!this->replaceScreenshotWithGuideButton)
+                    break;
+
+                eventClear(&screenshot_evt);
+
+                if (!down_start_tick) {
+                    down_start_tick = armGetSystemTick();
+                    isScreenshotPressed = true;
+                    Logger::info("Screenshot button clicked");
+                } else {
+                    down_start_tick    = 0;
+                    isScreenshotPressed = false;
+                    Logger::info("Screenshot button released");
+                }
+                break;
+            default:
+                break;
+        }
     }
 }
 

--- a/library/lib/platforms/switch/switch_wrapper.c
+++ b/library/lib/platforms/switch/switch_wrapper.c
@@ -48,6 +48,8 @@ void userAppInit()
 #endif
 
     romfsInit();
+    hidsysInitialize();
+    inssInitialize();
     plInitialize(PlServiceType_User);
     setsysInitialize();
     setInitialize();
@@ -73,6 +75,8 @@ void userAppExit()
     // system font
     plExit();
 
+    inssExit();
+    hidsysExit();
     romfsExit();
 
     if (nxlink_sock != -1)


### PR DESCRIPTION
Take a note that I added some c++20 specific code, so I've updated c++17 to 20 as well.

I didn't add any public access to replaceScreenshotWithGuideButton property, because I believe that this is highly Switch specific functionality, so to access it, you'l need to check platform first and call directly:

`((SwitchInputManager*) brls::Application::getPlatform()->getInputManager())->setReplaceScreenshotWithGuideButton(...)`

If you believe that this property could be useful for any other platform, I could move it to InputManager interface as well