### PR TITLE
ThreadPool added for concurrent async tasks

### DIFF
--- a/library/include/borealis/core/thread.hpp
+++ b/library/include/borealis/core/thread.hpp
@@ -59,7 +59,7 @@ extern void sync(const std::function<void()>& func);
  *
  * It's a shortcut for brls::Application::async(&func);
  */
-extern void async(const std::function<void()>& func);
+extern void async(const std::function<void()>& func, bool concurrent = true);
 
 extern size_t delay(long milliseconds, const std::function<void()>& func);
 

--- a/library/include/borealis/core/thread_pool.hpp
+++ b/library/include/borealis/core/thread_pool.hpp
@@ -1,0 +1,48 @@
+/*
+    Copyright 2025 XITRIX
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <thread>
+#include <functional>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+
+namespace brls {
+
+class ThreadPool {
+public:
+    explicit ThreadPool(int threads);
+    ~ThreadPool();
+
+    void async(std::function<void(void)> func);
+
+    static ThreadPool* global() { return _global; }
+private:
+
+    void threadEntry(int i);
+
+    std::mutex lock_;
+    std::condition_variable condVar_;
+    bool shutdown_;
+    std::queue<std::function<void(void)>> jobs_;
+    std::vector<std::thread> threads_;
+
+    static ThreadPool* _global;
+};
+
+} // namespace brls

--- a/library/lib/core/thread.cpp
+++ b/library/lib/core/thread.cpp
@@ -18,6 +18,7 @@
 
 #include <borealis/core/logger.hpp>
 #include <borealis/core/thread.hpp>
+#include <borealis/core/thread_pool.hpp>
 #include <exception>
 
 #ifdef BOREALIS_USE_STD_THREAD
@@ -49,9 +50,12 @@ void sync(const std::function<void()>& func)
     Threading::sync(func);
 }
 
-void async(const std::function<void()>& task)
+void async(const std::function<void()>& task, bool concurrent)
 {
-    Threading::async(task);
+    if (concurrent)
+        ThreadPool::global()->async(task);
+    else
+        Threading::async(task);
 }
 
 size_t delay(long milliseconds, const std::function<void()>& func)

--- a/library/lib/core/thread_pool.cpp
+++ b/library/lib/core/thread_pool.cpp
@@ -1,0 +1,82 @@
+/*
+    Copyright 2025 XITRIX
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <borealis/core/thread_pool.hpp>
+#include <borealis/core/logger.hpp>
+
+namespace brls {
+
+// Create global ThreadPool with default amount of threads (probably should be configurable)
+ThreadPool* ThreadPool::_global = new ThreadPool(8);
+
+ThreadPool::ThreadPool(int threads) : shutdown_(false) {
+    // Create the specified number of threads
+    threads_.reserve(threads);
+    for (int i = 0; i < threads; ++i)
+        threads_.emplace_back([this, i] { threadEntry(i); });
+}
+
+ThreadPool::~ThreadPool() {
+    {
+        // Unblock any threads and tell them to stop
+        std::unique_lock<std::mutex> l(lock_);
+
+        shutdown_ = true;
+        condVar_.notify_all();
+    }
+
+    // Wait for all threads to stop
+    brls::Logger::info("Joining threads");
+    for (auto &thread: threads_)
+        thread.join();
+}
+
+void ThreadPool::async(std::function<void(void)> func) {
+    // Place a job on the queue and unblock a thread
+    std::unique_lock<std::mutex> l(lock_);
+
+    jobs_.emplace(std::move(func));
+    condVar_.notify_one();
+}
+
+void ThreadPool::threadEntry(int i) {
+    std::function<void(void)> job;
+
+    while (true) {
+        {
+            std::unique_lock<std::mutex> l(lock_);
+
+            while (!shutdown_ && jobs_.empty())
+                condVar_.wait(l);
+
+            if (jobs_.empty()) {
+                // No jobs to do and we are shutting down
+                brls::Logger::info("Thread {} terminates", i);
+                return;
+            }
+
+//            brls::Logger::info("Thread {} does a job", i);
+            job = std::move(jobs_.front());
+            jobs_.pop();
+        }
+
+        // Do the job without holding any locks
+        job();
+    }
+
+}
+
+} // namespace brls


### PR DESCRIPTION
Issue:
In Moonlight-Switch app I could have 5 tabs with Hosts, on Tab's screen opening, it starts host status check by async CURL request. If I need to open 5th Tab I'll need to scroll throw other 4 tabs which with current solution will cause a chain of requests waiting for each other to complete.

Solution is to introduce ThreadPool which will be able to run tasks not in serial queue, but in parallel. 

I introduced it as part of `async` function by default so it will not require any modifications in existing code, which will allow to utilise multithreading out of the box, but it also could introduce issues if any part of code relies on current serial queue behaviour, so I think it could be a good approach to make default behaviour configurable, to not break any other apps before their developers will check that it works fine in their solutions.

