### PR TITLE
Desktop: Add keyboard shortcut action

### DIFF
--- a/library/include/borealis/core/actions.hpp
+++ b/library/include/borealis/core/actions.hpp
@@ -30,23 +30,183 @@ typedef std::function<bool(View*)> ActionListener;
 
 typedef int ActionIdentifier;
 
+typedef int BrlsKeyCode;
+
+struct BrlsKeyCombination
+{
+    BrlsKeyboardScancode code;
+    int mod;
+
+    explicit BrlsKeyCombination(const int key)
+    {
+        code = static_cast<BrlsKeyboardScancode>(key & 0xFFFF);
+        mod  = static_cast<BrlsKeyboardModifiers>((key >> 16) & 0xFFFF);
+    }
+
+    BrlsKeyCombination(const BrlsKeyboardScancode code) : code(code), mod(BRLS_KBD_MODIFIER_NONE) {}
+
+    BrlsKeyCombination(const BrlsKeyboardScancode code, const int mod) : code(code), mod(mod) {}
+
+    operator int() const
+    {
+        return mod << 16 | code;
+    }
+
+    bool operator ==(const int a) const
+    {
+        return (mod << 16 | code) == a;
+    }
+
+    bool operator !=(const int a) const
+    {
+        return (mod << 16 | code) != a;
+    }
+};
+
+class BrlsKeyState
+{
+public:
+    explicit BrlsKeyState(const BrlsKeyCombination keyComb): key(keyComb) {}
+
+    BrlsKeyCombination key;
+    bool pressed{};
+    Time repeatingStop{};
+
+    [[nodiscard]] int getModifiers() const
+    {
+        return this->key.mod;
+    }
+
+    [[nodiscard]] BrlsKeyboardScancode getScancode() const
+    {
+        return this->key.code;
+    }
+};
+
 #define ACTION_NONE -1
 
-struct Action
+enum ActionType
 {
-    enum ControllerButton button;
+    ACTION_GAMEPAD,
+    ACTION_KEYBOARD,
+    ACTION_COUNT,
+};
 
-    ActionIdentifier identifier;
-    std::string hintText;
-    bool available;
-    bool hidden;
-    bool allowRepeating;
-    enum Sound sound;
-    ActionListener actionListener;
-
-    bool operator==(const enum ControllerButton other)
+class Action
+{
+public:
+    Action(const int button, const ActionIdentifier identifier, const std::string& hintText,
+        const bool available, const bool hidden, const bool allowRepeating, const Sound sound, const ActionListener& actionListener)
     {
-        return this->button == other;
+        this->type           = ACTION_COUNT;
+        this->button         = button;
+        this->identifier     = identifier;
+        this->hintText       = hintText;
+        this->available      = available;
+        this->hidden         = hidden;
+        this->allowRepeating = allowRepeating;
+        this->sound          = sound;
+        this->actionListener = actionListener;
+    }
+
+    virtual ~Action() = default;
+
+    virtual bool operator==(const ControllerButton other) const
+    {
+        return this->type == ACTION_GAMEPAD && this->button == other;
+    }
+
+    virtual bool operator==(const BrlsKeyCode other) const
+    {
+        return this->type == ACTION_KEYBOARD && this->button == other;
+    }
+
+    [[nodiscard]] ActionIdentifier getIdentifier() const
+    {
+        return this->identifier;
+    }
+
+    [[nodiscard]] ActionType getType() const
+    {
+        return this->type;
+    }
+
+    [[nodiscard]] int getButton() const
+    {
+        return this->button;
+    }
+
+    [[nodiscard]] std::string getHintText() const
+    {
+        return this->hintText;
+    }
+
+    void setHintText(const std::string& hintText)
+    {
+        this->hintText = hintText;
+    }
+
+    [[nodiscard]] bool isAvailable() const
+    {
+        return this->available;
+    }
+
+    void setAvailable(const bool isAvailable)
+    {
+        this->available = isAvailable;
+    }
+
+    [[nodiscard]] bool isHidden() const
+    {
+        return this->hidden;
+    }
+
+    [[nodiscard]] bool isAllowRepeating() const
+    {
+        return this->allowRepeating;
+    }
+
+    [[nodiscard]] Sound getSound() const
+    {
+        return this->sound;
+    }
+
+    [[nodiscard]] ActionListener getActionListener() const
+    {
+        return this->actionListener;
+    }
+
+protected:
+    ActionType type{};
+    int button{};
+    ActionIdentifier identifier{};
+    std::string hintText{};
+    bool available{};
+    bool hidden{};
+    bool allowRepeating{};
+    Sound sound{};
+    ActionListener actionListener{};
+};
+
+class KeyboardAction final : public Action
+{
+public:
+    KeyboardAction(const BrlsKeyCode button, const ActionIdentifier identifier, const std::string& hintText,
+        const bool available, const bool hidden, const bool allowRepeating, const Sound sound, const ActionListener& actionListener):
+        Action(button, identifier, hintText, available, hidden, allowRepeating, sound, actionListener)
+    {
+        this->type = ACTION_KEYBOARD;
+    }
+};
+
+class GamepadAction final : public Action
+{
+public:
+    GamepadAction(const ControllerButton button, const ActionIdentifier identifier, const std::string& hintText,
+        const bool available, const bool hidden, const bool allowRepeating, const Sound sound, const ActionListener& actionListener):
+        Action(button, identifier, hintText, available, hidden, allowRepeating, sound, actionListener)
+    {
+        this->type = ACTION_GAMEPAD;
     }
 };
 

--- a/library/include/borealis/core/activity.hpp
+++ b/library/include/borealis/core/activity.hpp
@@ -134,7 +134,9 @@ class Activity
      * Returns the identifier for the action, so it can be unregistered later on. Returns ACTION_NONE if the
      * action was not registered.
      */
-    ActionIdentifier registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, bool allowRepeating = false, enum Sound sound = SOUND_NONE);
+    ActionIdentifier registerAction(const std::string& hintText, enum ControllerButton button, const ActionListener& actionListener, bool hidden = false, bool allowRepeating = false, enum Sound sound = SOUND_NONE);
+
+    ActionIdentifier registerAction(BrlsKeyCombination key, const ActionListener& actionListener, bool allowRepeating = false);
 
     /**
      * Unregisters an action with the given identifier on the content view.

--- a/library/include/borealis/core/application.hpp
+++ b/library/include/borealis/core/application.hpp
@@ -175,6 +175,8 @@ class Application
 
     static void onControllerButtonPressed(enum ControllerButton button, bool repeating);
 
+    static void onKeyboardPressed(BrlsKeyCombination key, bool repeating);
+
     /**
      * "Crashes" the app (displays a fullscreen CrashFrame)
      */
@@ -339,6 +341,10 @@ class Application
 
     static void tryDeinitFirstResponder(View* view);
 
+    static void addToWatchedKeys(const BrlsKeyCombination key);
+
+    static void removeWatchedKeys(const BrlsKeyCombination key);
+
   private:
     inline static bool inited               = false;
     inline static bool quitRequested        = false;
@@ -365,6 +371,9 @@ class Application
     static bool setInputType(InputType type);
 
     inline static InputType inputType = InputType::GAMEPAD;
+    inline static std::vector<BrlsKeyState> watchedKeys;
+    inline static std::vector<BrlsKeyState> oldWatchedKeys;
+    inline static std::unordered_map<int, int> watchedKeysMap;
 
     inline static void processInput();
     inline static bool internalMainLoop();
@@ -415,7 +424,7 @@ class Application
      * the given button
      * Returns true if at least one action has been fired
      */
-    static bool handleAction(char button, bool repeating);
+    static bool handleAction(ActionType type, int button, bool repeating);
 
     static void registerBuiltInXMLViews();
 

--- a/library/include/borealis/core/application.hpp
+++ b/library/include/borealis/core/application.hpp
@@ -339,6 +339,17 @@ class Application
         return drawCoursor;
     }
 
+    inline static bool isHintsLiteMode()
+    {
+        return hintsLiteMode;
+    }
+
+    // Set hints lite mode, which will only show hints for A button and B button
+    inline void static setHintsLiteMode(const bool value)
+    {
+        hintsLiteMode = value;
+    }
+
     static void tryDeinitFirstResponder(View* view);
 
     static void addToWatchedKeys(const BrlsKeyCombination key);
@@ -391,6 +402,7 @@ class Application
     inline static size_t globalFPS                      = 60;
     inline static Time limitedFrameTime                 = 0;
     inline static Time frameStartTime                   = 0;
+    inline static bool hintsLiteMode                    = false;
 
     inline static bool deactivatedBehavior = false;
     inline static bool activeEvent         = false;

--- a/library/include/borealis/core/input.hpp
+++ b/library/include/borealis/core/input.hpp
@@ -31,6 +31,7 @@ namespace brls
 
 typedef enum
 {
+    BRLS_KBD_MODIFIER_NONE  = 0x00,
     BRLS_KBD_MODIFIER_SHIFT = 0x01,
     BRLS_KBD_MODIFIER_CTRL  = 0x02,
     BRLS_KBD_MODIFIER_ALT   = 0x04,

--- a/library/include/borealis/core/touch/tap_gesture.hpp
+++ b/library/include/borealis/core/touch/tap_gesture.hpp
@@ -78,9 +78,9 @@ class TapGestureRecognizer : public GestureRecognizer
 
   private:
     TapGestureEvent tapEvent;
-    Point position;
-    GestureState lastState;
-    bool forceRecognision = false;
+    Point position{};
+    GestureState lastState{};
+    bool forceRecognision{};
 };
 
 } // namespace brls

--- a/library/include/borealis/core/view.hpp
+++ b/library/include/borealis/core/view.hpp
@@ -275,7 +275,7 @@ class View
     bool wireframeEnabled = false;
     bool clipsToBounds    = false;
 
-    std::vector<Action> actions;
+    std::vector<std::shared_ptr<Action>> actions;
     std::vector<GestureRecognizer*> gestureRecognizers;
 
     /**
@@ -1174,6 +1174,13 @@ class View
 
     void* getParentUserData();
 
+    typedef std::vector<std::shared_ptr<Action>>::iterator ActionIterator;
+
+    template <class ButtonType>
+    ActionIterator getAction(ButtonType button);
+
+    ActionIterator getAction(ActionIdentifier identifier);
+
     /**
      * Registers an action with the given parameters. The listener will be fired when the user presses
      * the key when the view is focused.
@@ -1186,7 +1193,14 @@ class View
      * Returns the identifier for the action, so it can be unregistered later on. Returns ACTION_NONE if the
      * action was not registered.
      */
-    ActionIdentifier registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, bool allowRepeating = false, enum Sound sound = SOUND_NONE);
+    template <class ButtonType, class ActionType>
+    ActionIdentifier registerAction(const std::string& hintText, ButtonType button, const ActionListener& actionListener, bool hidden = false, bool allowRepeating = false, enum Sound sound = SOUND_NONE);
+
+    ActionIdentifier registerAction(const std::string& hintText, ControllerButton button, const ActionListener& actionListener, bool hidden = false, bool allowRepeating = false, enum Sound sound = SOUND_NONE);
+
+    ActionIdentifier registerAction(BrlsKeyCombination key, const ActionListener& actionListener, bool allowRepeating = false);
+
+    void func(BrlsKeyCombination key);
 
     /**
      * Unregisters an action with the given identifier.
@@ -1196,11 +1210,11 @@ class View
     /**
      * Shortcut to register a generic "A OK" click action.
      */
-    void registerClickAction(ActionListener actionListener);
+    void registerClickAction(const ActionListener& actionListener);
 
-    void updateActionHint(enum ControllerButton button, std::string hintText);
+    void updateActionHint(enum ControllerButton button, const std::string& hintText);
     void setActionAvailable(enum ControllerButton button, bool available);
-    void setActionsAvailable(bool available);
+    void setActionsAvailable(bool available) const;
 
     void resetClickAnimation();
     void playClickAnimation(bool reverse = false, bool animateBack = true, bool force = false);
@@ -1211,7 +1225,7 @@ class View
 
     YGNode* getYGNode();
 
-    const std::vector<Action>& getActions();
+    const std::vector<std::shared_ptr<Action>>& getActions();
 
     /**
      * Get the vector of all gesture recognizers attached to that view.

--- a/library/include/borealis/platforms/switch/switch_input.hpp
+++ b/library/include/borealis/platforms/switch/switch_input.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <switch.h>
+#include <unordered_map>
 
 #include <borealis/core/input.hpp>
 
@@ -39,7 +40,7 @@ class SwitchInputManager : public InputManager
 
     void updateControllerState(ControllerState* state, int controller) override;
 
-    bool getKeyboardKeyState(BrlsKeyboardScancode state) override;
+    bool getKeyboardKeyState(BrlsKeyboardScancode key) override;
 
     void updateTouchStates(std::vector<RawTouchState>* states) override;
 
@@ -75,14 +76,15 @@ class SwitchInputManager : public InputManager
     HidSixAxisSensorHandle m_six_axis_sensor_handle[4]; // All for player 1, player 2 not supported
 
     std::vector<bool> m_hid_keyboard_state;
+    std::unordered_map<int, BrlsKeyboardScancode> m_hid_brls_map;
+    std::unordered_map<BrlsKeyboardScancode, int> m_brls_hid_map;
 
     void initCursor(NVGcontext* vg);
     void handleMouse();
     void handleKeyboard();
     void handleControllerSensors();
     void upToDateMouseState();
-    BrlsKeyboardScancode switchKeyToGlfwKey(int key);
-    int glfwKeyToVKKey(BrlsKeyboardScancode key);
+    void hidInitializeKeyboardMap();
     void updateControllerStateInner(ControllerState* state, PadState* pad);
     void sendRumbleInternal(HidVibrationDeviceHandle vibration_device[2], HidVibrationValue vibration_values[2],
         unsigned short lowFreqMotor, unsigned short highFreqMotor);

--- a/library/include/borealis/views/edit_text_dialog.hpp
+++ b/library/include/borealis/views/edit_text_dialog.hpp
@@ -30,7 +30,6 @@ class EditTextDialog : public Box
     Event<Point> layoutEvent;
     Event<> backspaceEvent, cancelEvent, summitEvent;
     Event<std::string> clipboardEvent;
-    Event<KeyState>::Subscription keyEvent;
     bool init = false;
 
     BRLS_BIND(brls::Label, header, "brls/dialog/header");

--- a/library/include/borealis/views/hint.hpp
+++ b/library/include/borealis/views/hint.hpp
@@ -28,11 +28,11 @@ namespace brls
 class Hint : public Box
 {
   public:
-    Hint(Action action, bool allowAButtonTouch = false);
+    Hint(std::shared_ptr<Action> action, bool allowAButtonTouch = false);
     static std::string getKeyIcon(ControllerButton button, bool ignoreKeysSwap = false);
 
   private:
-    Action action;
+    std::shared_ptr<Action> action;
 
     BRLS_BIND(Label, icon, "icon");
     BRLS_BIND(Label, hint, "hint");
@@ -73,7 +73,6 @@ class Hints : public Box
     bool forceShown             = false;
 
     VoidEvent::Subscription hintSubscription;
-    static bool actionsSortFunc(Action a, Action b);
 };
 
 } // namespace brls

--- a/library/lib/core/activity.cpp
+++ b/library/lib/core/activity.cpp
@@ -117,10 +117,18 @@ bool Activity::isHidden()
     return this->contentView->isHidden();
 }
 
-ActionIdentifier Activity::registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden, bool allowRepeating, enum Sound sound)
+ActionIdentifier Activity::registerAction(const std::string& hintText, const enum ControllerButton button, const ActionListener& actionListener, const bool hidden, const bool allowRepeating, const enum Sound sound)
 {
     if (this->contentView)
         return this->contentView->registerAction(hintText, button, actionListener, hidden, allowRepeating, sound);
+
+    return ACTION_NONE;
+}
+
+ActionIdentifier Activity::registerAction(const BrlsKeyCombination key, const ActionListener& actionListener, const bool allowRepeating)
+{
+    if (this->contentView)
+        return this->contentView->registerAction(key, actionListener, allowRepeating);
 
     return ACTION_NONE;
 }

--- a/library/lib/core/application.cpp
+++ b/library/lib/core/application.cpp
@@ -399,6 +399,97 @@ void Application::processInput()
     }
 
     oldControllerState = controllerState;
+
+    // Trigger keyboard events
+    const bool ctrlPressed  = inputManager->getKeyboardKeyState(BRLS_KBD_KEY_LEFT_CONTROL) || inputManager->getKeyboardKeyState(BRLS_KBD_KEY_RIGHT_CONTROL);
+    const bool altPressed   = inputManager->getKeyboardKeyState(BRLS_KBD_KEY_LEFT_ALT) || inputManager->getKeyboardKeyState(BRLS_KBD_KEY_RIGHT_ALT);
+    const bool shiftPressed = inputManager->getKeyboardKeyState(BRLS_KBD_KEY_LEFT_SHIFT) || inputManager->getKeyboardKeyState(BRLS_KBD_KEY_RIGHT_SHIFT);
+    const bool metaPressed  = inputManager->getKeyboardKeyState(BRLS_KBD_KEY_LEFT_SUPER) || inputManager->getKeyboardKeyState(BRLS_KBD_KEY_RIGHT_SUPER);
+    for (int i = 0; i < watchedKeys.size(); i++)
+    {
+        auto& watchedKey    = watchedKeys[i];
+        auto& oldWatchedKey = oldWatchedKeys[i];
+
+        const BrlsKeyboardScancode scancode = watchedKey.getScancode();
+        if (scancode == BRLS_KBD_KEY_UNKNOWN)
+        {
+            continue;
+        }
+
+        watchedKey.pressed = inputManager->getKeyboardKeyState(scancode);
+        if (static_cast<bool>(watchedKey.getModifiers() & BRLS_KBD_MODIFIER_SHIFT) != shiftPressed ||
+            static_cast<bool>(watchedKey.getModifiers() & BRLS_KBD_MODIFIER_CTRL) != ctrlPressed ||
+            static_cast<bool>(watchedKey.getModifiers() & BRLS_KBD_MODIFIER_ALT) != altPressed ||
+            static_cast<bool>(watchedKey.getModifiers() & BRLS_KBD_MODIFIER_META) != metaPressed)
+        {
+            // If the key is pressed but the modifiers are not, unpressed it
+            watchedKey.pressed = false;
+        }
+
+        if (watchedKey.pressed)
+        {
+            repeating = watchedKey.repeatingStop > 0 && cpuTime > watchedKey.repeatingStop;
+
+            if (repeating)
+                watchedKey.repeatingStop = cpuTime + BUTTON_REPEAT_DELAY;
+
+            if (!oldWatchedKey.pressed)
+                watchedKey.repeatingStop = cpuTime + BUTTOM_REPEAT_TRIGGER;
+
+            if (!oldWatchedKey.pressed || repeating)
+                onKeyboardPressed(watchedKey.key, repeating);
+        }
+        else
+        {
+            watchedKey.repeatingStop = 0;
+        }
+
+        oldWatchedKeys[i] = watchedKeys[i];
+    }
+}
+
+void Application::addToWatchedKeys(const BrlsKeyCombination key)
+{
+    if (watchedKeysMap.count(key) == 0)
+    {
+        watchedKeysMap[key] = 0;
+        watchedKeys.emplace_back(key);
+        oldWatchedKeys.emplace_back(key);
+    }
+    watchedKeysMap[key] = watchedKeysMap[key] + 1;
+}
+
+void Application::removeWatchedKeys(const BrlsKeyCombination key)
+{
+    if (watchedKeysMap.count(key) == 0 || watchedKeysMap[key] <= 0)
+    {
+        // Key is not watched, nothing to do
+        return;
+    }
+    watchedKeysMap[key] = watchedKeysMap[key] - 1;
+    if (watchedKeysMap[key] > 0)
+    {
+        // Key is still watched, nothing to do
+        return;
+    }
+
+    // Key is not watched anymore, remove it from the lists
+    for (auto it = watchedKeys.begin(); it != watchedKeys.end(); ++it)
+    {
+        if (it->key == key)
+        {
+            watchedKeys.erase(it);
+            break;
+        }
+    }
+    for (auto it = oldWatchedKeys.begin(); it != oldWatchedKeys.end(); ++it)
+    {
+        if (it->key == key)
+        {
+            oldWatchedKeys.erase(it);
+            break;
+        }
+    }
 }
 
 Platform* Application::getPlatform()
@@ -487,7 +578,7 @@ void Application::onControllerButtonPressed(enum ControllerButton button, bool r
 {
 
     // Actions
-    if (Application::handleAction(button, repeating))
+    if (Application::handleAction(ACTION_GAMEPAD, button, repeating))
         return;
 
     // Navigation
@@ -513,6 +604,11 @@ void Application::onControllerButtonPressed(enum ControllerButton button, bool r
 
     // Only play the error sound if no action applied
     Application::getAudioPlayer()->play(SOUND_CLICK_ERROR);
+}
+
+void Application::onKeyboardPressed(BrlsKeyCombination key, bool repeating)
+{
+    Application::handleAction(ACTION_KEYBOARD, key, repeating);
 }
 
 bool Application::setInputType(InputType type)
@@ -590,23 +686,17 @@ double Application::getDeactivatedFrameTime()
     return 1.0 / Application::deactivatedFPS;
 }
 
-bool Application::handleAction(char button, bool repeating)
+bool Application::handleAction(const ActionType type, const int button, const bool repeating)
 {
     // Dismiss if input type was changed
-    if (button == BUTTON_A && setInputType(InputType::GAMEPAD))
+    if (type == ACTION_GAMEPAD && button == BUTTON_A && setInputType(InputType::GAMEPAD))
         return false;
-
-    //    if (button == BUTTON_B && setInputType(InputType::GAMEPAD))
-    //    {
-    //        activitiesStack.back()->getContentView()->dismiss();
-    //        return true;
-    //    }
 
     if (Application::activitiesStack.empty())
         return false;
 
     View* hintParent = Application::currentFocus;
-    std::set<enum ControllerButton> consumedButtons;
+    std::set<int> consumedButtons;
 
     if (!hintParent)
         hintParent = Application::activitiesStack[Application::activitiesStack.size() - 1]->getContentView();
@@ -615,23 +705,26 @@ bool Application::handleAction(char button, bool repeating)
     {
         for (auto& action : hintParent->getActions())
         {
-            if (action.button != static_cast<enum ControllerButton>(button))
+            if (action->getType() != type)
                 continue;
 
-            if (consumedButtons.find(action.button) != consumedButtons.end())
+            if (action->getButton() != button)
                 continue;
 
-            if (action.available && (!repeating || action.allowRepeating))
+            if (consumedButtons.find(action->getButton()) != consumedButtons.end())
+                continue;
+
+            if (action->isAvailable() && (!repeating || action->isAllowRepeating()))
             {
-                if (action.actionListener(hintParent))
+                if (action->getActionListener()(hintParent))
                 {
                     setInputType(InputType::GAMEPAD);
-                    if (button == BUTTON_A)
+                    if (type == ACTION_GAMEPAD && button == BUTTON_A)
                         hintParent->playClickAnimation();
 
-                    Application::getAudioPlayer()->play(action.sound);
+                    getAudioPlayer()->play(action->getSound());
 
-                    consumedButtons.insert(action.button);
+                    consumedButtons.insert(action->getButton());
                 }
             }
         }

--- a/library/lib/core/application.cpp
+++ b/library/lib/core/application.cpp
@@ -450,7 +450,7 @@ void Application::processInput()
 
 void Application::addToWatchedKeys(const BrlsKeyCombination key)
 {
-    if (watchedKeysMap.count(key) == 0)
+    if (watchedKeysMap.count(key) == 0 || watchedKeysMap[key] <= 0)
     {
         watchedKeysMap[key] = 0;
         watchedKeys.emplace_back(key);

--- a/library/lib/core/touch/tap_gesture.cpp
+++ b/library/lib/core/touch/tap_gesture.cpp
@@ -27,10 +27,10 @@ TapGestureRecognizer::TapGestureRecognizer(View* view, TapGestureConfig config)
             Application::giveFocus(view);
         for (auto& action : view->getActions())
         {
-            if (action.button != static_cast<enum ControllerButton>(BUTTON_A))
+            if (action->getType() != ACTION_GAMEPAD || action->getButton() != BUTTON_A)
                 continue;
 
-            if (action.available)
+            if (action->isAvailable())
             {
                 if (config.highlightOnSelect)
                     view->playClickAnimation(status.state != GestureState::UNSURE);
@@ -45,8 +45,8 @@ TapGestureRecognizer::TapGestureRecognizer(View* view, TapGestureConfig config)
                         *soundToPlay = config.failedSound;
                         break;
                     case GestureState::END:
-                        if (action.actionListener(view))
-                            *soundToPlay = action.sound;
+                        if (action->getActionListener()(view))
+                            *soundToPlay = action->getSound();
                         break;
                     default:
                         break;

--- a/library/lib/core/view.cpp
+++ b/library/lib/core/view.cpp
@@ -295,7 +295,7 @@ YGNode* View::getYGNode()
     return this->ygNode;
 }
 
-const std::vector<Action>& View::getActions()
+const std::vector<std::shared_ptr<Action> >& View::getActions()
 {
     return this->actions;
 }
@@ -744,50 +744,88 @@ void View::drawBackground(NVGcontext* vg, FrameContext* ctx, Style style, Rect f
     }
 }
 
-ActionIdentifier View::registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden, bool allowRepeating, enum Sound sound)
+template <class ButtonType>
+View::ActionIterator View::getAction(ButtonType button)
 {
-    ActionIdentifier nextIdentifier = (this->actions.size() == 0) ? 1 : this->actions.back().identifier + 1;
+    return std::find_if(this->actions.begin(), this->actions.end(), [button](const std::shared_ptr<Action>& action)
+    {
+        return *action == button;
+    });
+}
 
-    if (auto it = std::find(this->actions.begin(), this->actions.end(), button); it != this->actions.end())
-        *it = { button, nextIdentifier, hintText, true, hidden, allowRepeating, sound, actionListener };
+View::ActionIterator View::getAction(ActionIdentifier identifier)
+{
+    return std::find_if(this->actions.begin(), this->actions.end(), [identifier](const std::shared_ptr<Action>& action)
+    {
+        return action->getIdentifier() == identifier;
+    });
+}
+
+template <class ButtonType, class ActionType>
+ActionIdentifier View::registerAction(const std::string& hintText, ButtonType button, const ActionListener& actionListener, bool hidden, bool allowRepeating, enum Sound sound)
+{
+    ActionIdentifier nextIdentifier = (this->actions.size() == 0) ? 1 : this->actions.back()->getIdentifier() + 1;
+    auto newAction                  = std::make_shared<ActionType>(button, nextIdentifier, hintText, true, hidden, allowRepeating, sound, actionListener);
+
+    auto it = getAction(button);
+    if (it != this->actions.end())
+    {
+        *it = newAction;
+    }
     else
-        this->actions.push_back({ button, nextIdentifier, hintText, true, hidden, allowRepeating, sound, actionListener });
+    {
+        this->actions.push_back(newAction);
+    }
 
     return nextIdentifier;
 }
 
-void View::unregisterAction(ActionIdentifier identifier)
+ActionIdentifier View::registerAction(const std::string& hintText, const ControllerButton button, const ActionListener& actionListener, const bool hidden, const bool allowRepeating, const enum Sound sound)
 {
-    auto is_matched_action = [identifier](Action action) {
-        return action.identifier == identifier;
-    };
-    if (auto it = std::find_if(this->actions.begin(), this->actions.end(), is_matched_action); it != this->actions.end())
-        this->actions.erase(it);
+    return registerAction<ControllerButton, GamepadAction>(hintText, button, actionListener, hidden, allowRepeating, sound);
 }
 
-void View::registerClickAction(ActionListener actionListener)
+ActionIdentifier View::registerAction(const BrlsKeyCombination key, const ActionListener& actionListener, const bool allowRepeating)
+{
+    Application::addToWatchedKeys(key);
+    return registerAction<BrlsKeyCode, KeyboardAction>("", key, actionListener, true, allowRepeating, SOUND_NONE);
+}
+
+void View::unregisterAction(ActionIdentifier identifier)
+{
+    if (const auto it = getAction(identifier); it != this->actions.end())
+    {
+        if ((*it)->getType() == ACTION_KEYBOARD)
+        {
+            Application::removeWatchedKeys(BrlsKeyCombination{ (*it)->getButton() });
+        }
+        this->actions.erase(it);
+    }
+}
+
+void View::registerClickAction(const ActionListener& actionListener)
 {
     this->registerAction("hints/ok"_i18n, BUTTON_A, actionListener, false, false, SOUND_CLICK);
 }
 
-void View::updateActionHint(enum ControllerButton button, std::string hintText)
+void View::updateActionHint(const enum ControllerButton button, const std::string& hintText)
 {
-    if (auto it = std::find(this->actions.begin(), this->actions.end(), button); it != this->actions.end())
-        it->hintText = hintText;
+    if (const auto it = getAction(button); it != this->actions.end())
+        (*it)->setHintText(hintText);
 }
 
-void View::setActionAvailable(enum ControllerButton button, bool available)
+void View::setActionAvailable(const enum ControllerButton button, const bool available)
 {
-    if (auto it = std::find(this->actions.begin(), this->actions.end(), button); it != this->actions.end())
-        it->available = available;
+    if (const auto it = getAction(button); it != this->actions.end())
+        (*it)->setAvailable(available);
 
     Application::getGlobalHintsUpdateEvent()->fire();
 }
 
-void View::setActionsAvailable(bool available)
+void View::setActionsAvailable(const bool available) const
 {
-    for (size_t i = 0; i < this->actions.size(); i++)
-        this->actions[i].available = available;
+    for (const auto& action : this->actions)
+        action->setAvailable(available);
 
     Application::getGlobalHintsUpdateEvent()->fire();
 }

--- a/library/lib/core/view.cpp
+++ b/library/lib/core/view.cpp
@@ -1520,6 +1520,14 @@ View::~View()
         this->parentUserdata = nullptr;
     }
 
+    for (const auto& action : this->actions)
+    {
+        if (action->getType() == ACTION_KEYBOARD)
+        {
+            Application::removeWatchedKeys(BrlsKeyCombination{ action->getButton() });
+        }
+    }
+
     // Focus sanity check
     if (Application::getCurrentFocus() == this)
         Application::giveFocus(nullptr);

--- a/library/lib/platforms/glfw/glfw_input.cpp
+++ b/library/lib/platforms/glfw/glfw_input.cpp
@@ -50,24 +50,6 @@ static const size_t GLFW_BUTTONS_MAPPING[GLFW_GAMEPAD_BUTTON_MAX] = {
     BUTTON_LEFT, // GLFW_GAMEPAD_BUTTON_DPAD_LEFT
 };
 
-static const size_t GLFW_GAMEPAD_TO_KEYBOARD[GLFW_GAMEPAD_BUTTON_MAX] = {
-    GLFW_KEY_ENTER, // GLFW_GAMEPAD_BUTTON_A
-    GLFW_KEY_ESCAPE, // GLFW_GAMEPAD_BUTTON_B
-    GLFW_KEY_X, // GLFW_GAMEPAD_BUTTON_X
-    GLFW_KEY_Y, // GLFW_GAMEPAD_BUTTON_Y
-    GLFW_KEY_L, // GLFW_GAMEPAD_BUTTON_LEFT_BUMPER
-    GLFW_KEY_R, // GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER
-    GLFW_KEY_F1, // GLFW_GAMEPAD_BUTTON_BACK
-    GLFW_KEY_F2, // GLFW_GAMEPAD_BUTTON_START
-    GLFW_GAMEPAD_BUTTON_NONE, // GLFW_GAMEPAD_BUTTON_GUIDE
-    GLFW_KEY_Q, // GLFW_GAMEPAD_BUTTON_LEFT_THUMB
-    GLFW_KEY_P, // GLFW_GAMEPAD_BUTTON_RIGHT_THUMB
-    GLFW_KEY_UP, // GLFW_GAMEPAD_BUTTON_DPAD_UP
-    GLFW_KEY_RIGHT, // GLFW_GAMEPAD_BUTTON_DPAD_RIGHT
-    GLFW_KEY_DOWN, // GLFW_GAMEPAD_BUTTON_DPAD_DOWN
-    GLFW_KEY_LEFT, // GLFW_GAMEPAD_BUTTON_DPAD_LEFT
-};
-
 static const size_t GLFW_AXIS_MAPPING[GLFW_GAMEPAD_AXIS_MAX] = {
     LEFT_X,
     LEFT_Y,
@@ -282,14 +264,6 @@ void GLFWInputManager::updateUnifiedControllerState(ControllerState* state)
     }
 
     // Add keyboard keys on top of gamepad buttons
-    for (size_t i = 2; i < GLFW_GAMEPAD_BUTTON_MAX; i++)
-    {
-        size_t brlsButton = GLFW_BUTTONS_MAPPING[i];
-        size_t key        = GLFW_GAMEPAD_TO_KEYBOARD[i];
-        if (key != GLFW_GAMEPAD_BUTTON_NONE)
-            state->buttons[brlsButton] |= glfwGetKey(this->window, key) != 0;
-    }
-
     if (Application::isSwapInputKeys()) {
         state->buttons[BUTTON_B] |= glfwGetKey(this->window, GLFW_KEY_KP_ENTER) != 0;
         state->buttons[BUTTON_B] |= glfwGetKey(this->window, GLFW_KEY_ENTER) != 0;
@@ -302,6 +276,11 @@ void GLFWInputManager::updateUnifiedControllerState(ControllerState* state)
         state->buttons[BUTTON_B] |= glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_RIGHT) == GLFW_PRESS;
     }
     state->buttons[BUTTON_X] |= (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_MIDDLE) == GLFW_PRESS);
+
+    state->buttons[BUTTON_UP] |= glfwGetKey(this->window, GLFW_KEY_UP) != 0;
+    state->buttons[BUTTON_RIGHT] |= glfwGetKey(this->window, GLFW_KEY_RIGHT) != 0;
+    state->buttons[BUTTON_DOWN] |= glfwGetKey(this->window, GLFW_KEY_DOWN) != 0;
+    state->buttons[BUTTON_LEFT] |= glfwGetKey(this->window, GLFW_KEY_LEFT) != 0;
 
     state->buttons[BUTTON_NAV_UP] |= state->buttons[BUTTON_UP];
     state->buttons[BUTTON_NAV_RIGHT] |= state->buttons[BUTTON_RIGHT];

--- a/library/lib/platforms/sdl/sdl_input.cpp
+++ b/library/lib/platforms/sdl/sdl_input.cpp
@@ -316,24 +316,6 @@ static const size_t SDL_BUTTONS_MAPPING[SDL_GAMEPAD_BUTTON_MAX] = {
     BUTTON_RIGHT, //    SDL_CONTROLLER_BUTTON_DPAD_RIGHT
 };
 
-static const size_t SDL_GAMEPAD_TO_KEYBOARD[SDL_GAMEPAD_BUTTON_MAX] = {
-    SDL_SCANCODE_RETURN, // SDL_CONTROLLER_BUTTON_A
-    SDL_SCANCODE_ESCAPE, // SDL_CONTROLLER_BUTTON_B
-    SDL_SCANCODE_X, // SDL_CONTROLLER_BUTTON_X
-    SDL_SCANCODE_Y, // SDL_CONTROLLER_BUTTON_Y
-    SDL_SCANCODE_F1, // SDL_CONTROLLER_BUTTON_BACK
-    SDL_SCANCODE_UNKNOWN, // SDL_CONTROLLER_BUTTON_GUIDE
-    SDL_SCANCODE_F2, // SDL_CONTROLLER_BUTTON_START
-    SDL_SCANCODE_Q, // SDL_CONTROLLER_BUTTON_LEFTSTICK
-    SDL_SCANCODE_P, // SDL_CONTROLLER_BUTTON_RIGHTSTICK
-    SDL_SCANCODE_L, // SDL_CONTROLLER_BUTTON_LEFTSHOULDER
-    SDL_SCANCODE_R, // SDL_CONTROLLER_BUTTON_RIGHTSHOULDER
-    SDL_SCANCODE_UP, // SDL_CONTROLLER_BUTTON_DPAD_UP
-    SDL_SCANCODE_DOWN, // SDL_CONTROLLER_BUTTON_DPAD_DOWN
-    SDL_SCANCODE_LEFT, // SDL_CONTROLLER_BUTTON_DPAD_LEFT
-    SDL_SCANCODE_RIGHT, // SDL_CONTROLLER_BUTTON_DPAD_RIGHT
-};
-
 static std::unordered_map<SDL_Scancode, int> keyboardKeys {};
 
 static const size_t SDL_AXIS_MAPPING[SDL_GAMEPAD_AXIS_MAX] = {
@@ -496,13 +478,6 @@ void SDLInputManager::updateUnifiedControllerState(ControllerState* state)
     }
 
     // Add keyboard keys on top of gamepad buttons
-    for (size_t i = 2; i < SDL_GAMEPAD_BUTTON_MAX; i++)
-    {
-        size_t brlsButton = SDL_BUTTONS_MAPPING[i];
-        size_t key        = SDL_GAMEPAD_TO_KEYBOARD[i];
-        if (key != SDL_SCANCODE_UNKNOWN)
-            state->buttons[brlsButton] |= getKeyboardKeys((SDL_Scancode)key);
-    }
     if (Application::isSwapInputKeys())
     {
         state->buttons[BUTTON_B] |= getKeyboardKeys(SDL_SCANCODE_KP_ENTER);
@@ -520,6 +495,11 @@ void SDLInputManager::updateUnifiedControllerState(ControllerState* state)
 
     // Android tv remote control
     state->buttons[BUTTON_X] |= getKeyboardKeys(SDL_SCANCODE_MENU);
+
+    state->buttons[BUTTON_UP] |= getKeyboardKeys(SDL_SCANCODE_UP);
+    state->buttons[BUTTON_RIGHT] |= getKeyboardKeys(SDL_SCANCODE_RIGHT);
+    state->buttons[BUTTON_DOWN] |= getKeyboardKeys(SDL_SCANCODE_DOWN);
+    state->buttons[BUTTON_LEFT] |= getKeyboardKeys(SDL_SCANCODE_LEFT);
 
     state->buttons[BUTTON_NAV_UP] |= state->buttons[BUTTON_UP];
     state->buttons[BUTTON_NAV_RIGHT] |= state->buttons[BUTTON_RIGHT];

--- a/library/lib/platforms/switch/switch_input.cpp
+++ b/library/lib/platforms/switch/switch_input.cpp
@@ -177,6 +177,22 @@ void SwitchInputManager::updateUnifiedControllerState(ControllerState* state)
                 state->axes[j] = 1;
         }
     }
+
+    state->buttons[BUTTON_NAV_UP] |= getKeyboardKeyState(BRLS_KBD_KEY_UP);
+    state->buttons[BUTTON_NAV_RIGHT] |= getKeyboardKeyState(BRLS_KBD_KEY_RIGHT);
+    state->buttons[BUTTON_NAV_DOWN] |= getKeyboardKeyState(BRLS_KBD_KEY_DOWN);
+    state->buttons[BUTTON_NAV_LEFT] |= getKeyboardKeyState(BRLS_KBD_KEY_LEFT);
+
+    if (Application::isSwapInputKeys())
+    {
+        state->buttons[BUTTON_B] |= getKeyboardKeyState(BRLS_KBD_KEY_ENTER);
+        state->buttons[BUTTON_A] |= getKeyboardKeyState(BRLS_KBD_KEY_ESCAPE);
+    }
+    else
+    {
+        state->buttons[BUTTON_A] |= getKeyboardKeyState(BRLS_KBD_KEY_ENTER);
+        state->buttons[BUTTON_B] |= getKeyboardKeyState(BRLS_KBD_KEY_ESCAPE);
+    }
 }
 
 short SwitchInputManager::getControllersConnectedCount()
@@ -247,22 +263,6 @@ void SwitchInputManager::updateControllerStateInner(ControllerState* state, PadS
 
     state->axes[LEFT_Z]  = 0; // SWITCH NOT SUPPORT ZL AXIS
     state->axes[RIGHT_Z] = 0; // SWITCH NOT SUPPORT ZR AXIS
-
-    state->buttons[BUTTON_NAV_UP] |= getKeyboardKeyState(BRLS_KBD_KEY_UP);
-    state->buttons[BUTTON_NAV_RIGHT] |= getKeyboardKeyState(BRLS_KBD_KEY_RIGHT);
-    state->buttons[BUTTON_NAV_DOWN] |= getKeyboardKeyState(BRLS_KBD_KEY_DOWN);
-    state->buttons[BUTTON_NAV_LEFT] |= getKeyboardKeyState(BRLS_KBD_KEY_LEFT);
-
-    if (Application::isSwapInputKeys())
-    {
-        state->buttons[BUTTON_B] |= getKeyboardKeyState(BRLS_KBD_KEY_ENTER);
-        state->buttons[BUTTON_A] |= getKeyboardKeyState(BRLS_KBD_KEY_ESCAPE);
-    }
-    else
-    {
-        state->buttons[BUTTON_A] |= getKeyboardKeyState(BRLS_KBD_KEY_ENTER);
-        state->buttons[BUTTON_B] |= getKeyboardKeyState(BRLS_KBD_KEY_ESCAPE);
-    }
 }
 
 bool SwitchInputManager::getKeyboardKeyState(BrlsKeyboardScancode key)

--- a/library/lib/platforms/switch/switch_input.cpp
+++ b/library/lib/platforms/switch/switch_input.cpp
@@ -116,17 +116,18 @@ SwitchInputManager::SwitchInputManager()
 
     hidInitializeMouse();
     hidInitializeKeyboard();
+    hidInitializeKeyboardMap();
 
     m_hid_keyboard_state.assign(256, false);
 
     // It's necessary to initialize these separately as they all have different handle values
-	hidGetSixAxisSensorHandles(&this->m_six_axis_sensor_handle[0], 1, HidNpadIdType_Handheld, HidNpadStyleTag_NpadHandheld);
-	hidGetSixAxisSensorHandles(&this->m_six_axis_sensor_handle[1], 1, HidNpadIdType_No1, HidNpadStyleTag_NpadFullKey);
-	hidGetSixAxisSensorHandles(&this->m_six_axis_sensor_handle[2], 2, HidNpadIdType_No1, HidNpadStyleTag_NpadJoyDual);
-	hidStartSixAxisSensor(this->m_six_axis_sensor_handle[0]);
-	hidStartSixAxisSensor(this->m_six_axis_sensor_handle[1]);
-	hidStartSixAxisSensor(this->m_six_axis_sensor_handle[2]);
-	hidStartSixAxisSensor(this->m_six_axis_sensor_handle[3]);
+    hidGetSixAxisSensorHandles(&this->m_six_axis_sensor_handle[0], 1, HidNpadIdType_Handheld, HidNpadStyleTag_NpadHandheld);
+    hidGetSixAxisSensorHandles(&this->m_six_axis_sensor_handle[1], 1, HidNpadIdType_No1, HidNpadStyleTag_NpadFullKey);
+    hidGetSixAxisSensorHandles(&this->m_six_axis_sensor_handle[2], 2, HidNpadIdType_No1, HidNpadStyleTag_NpadJoyDual);
+    hidStartSixAxisSensor(this->m_six_axis_sensor_handle[0]);
+    hidStartSixAxisSensor(this->m_six_axis_sensor_handle[1]);
+    hidStartSixAxisSensor(this->m_six_axis_sensor_handle[2]);
+    hidStartSixAxisSensor(this->m_six_axis_sensor_handle[3]);
 }
 
 SwitchInputManager::~SwitchInputManager()
@@ -137,9 +138,9 @@ SwitchInputManager::~SwitchInputManager()
         nvgDeleteImage(vg, this->cursorTexture);
 
     hidStopSixAxisSensor(this->m_six_axis_sensor_handle[0]);
-	hidStopSixAxisSensor(this->m_six_axis_sensor_handle[1]);
-	hidStopSixAxisSensor(this->m_six_axis_sensor_handle[2]);
-	hidStopSixAxisSensor(this->m_six_axis_sensor_handle[3]);
+    hidStopSixAxisSensor(this->m_six_axis_sensor_handle[1]);
+    hidStopSixAxisSensor(this->m_six_axis_sensor_handle[2]);
+    hidStopSixAxisSensor(this->m_six_axis_sensor_handle[3]);
 
 }
 
@@ -152,10 +153,10 @@ void SwitchInputManager::clearVibration(int controller)
 
 void SwitchInputManager::updateUnifiedControllerState(ControllerState* state)
 {
-    for (size_t i = 0; i < _BUTTON_MAX; i++)
+    for (size_t i         = 0; i < _BUTTON_MAX; i++)
         state->buttons[i] = false;
 
-    for (size_t i = 0; i < _AXES_MAX; i++)
+    for (size_t i      = 0; i < _AXES_MAX; i++)
         state->axes[i] = 0;
 
     auto connected = getControllersConnectedCount();
@@ -244,7 +245,7 @@ void SwitchInputManager::updateControllerStateInner(ControllerState* state, PadS
         state->axes[RIGHT_Y] = 0;
     }
 
-    state->axes[LEFT_Z] = 0;  // SWITCH NOT SUPPORT ZL AXIS
+    state->axes[LEFT_Z]  = 0; // SWITCH NOT SUPPORT ZL AXIS
     state->axes[RIGHT_Z] = 0; // SWITCH NOT SUPPORT ZR AXIS
 
     state->buttons[BUTTON_NAV_UP] |= getKeyboardKeyState(BRLS_KBD_KEY_UP);
@@ -255,12 +256,7 @@ void SwitchInputManager::updateControllerStateInner(ControllerState* state, PadS
 
 bool SwitchInputManager::getKeyboardKeyState(BrlsKeyboardScancode key)
 {
-    for (int i = 0; i < 256; ++i)
-    {
-        if (key == switchKeyToGlfwKey(i))
-            return m_hid_keyboard_state[i];
-    }
-    return false;
+    return m_hid_keyboard_state[m_brls_hid_map[key]];
 }
 
 void SwitchInputManager::updateTouchStates(std::vector<RawTouchState>* states)
@@ -389,11 +385,11 @@ void SwitchInputManager::handleKeyboard()
             auto is_pressed = (state.keys[i / 64] & (1ul << (i % 64))) != 0;
             if (m_hid_keyboard_state[i] != is_pressed)
             {
-                m_hid_keyboard_state[i]      = is_pressed;
-                BrlsKeyboardScancode glfwKey = switchKeyToGlfwKey(i);
+                m_hid_keyboard_state[i]            = is_pressed;
+                const BrlsKeyboardScancode brlsKey = m_hid_brls_map[i];
 
-                KeyState keyState;
-                keyState.key     = glfwKey;
+                KeyState keyState{};
+                keyState.key     = brlsKey;
                 keyState.pressed = is_pressed;
 
                 if (state.modifiers & HidKeyboardModifier_LeftAlt)
@@ -420,25 +416,40 @@ void SwitchInputManager::handleKeyboard()
 
 void SwitchInputManager::handleControllerSensors()
 {
-	HidSixAxisSensorState sixaxis = {0};
+    HidSixAxisSensorState sixaxis = { 0 };
 
-	uint64_t style_set = padGetStyleSet(&padsState[0]);
+    uint64_t style_set = padGetStyleSet(&padsState[0]);
     if (padStateHandheld.active_handheld)
-		hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[0], &sixaxis, 1);
-	else if(style_set & HidNpadStyleTag_NpadFullKey)
-		hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[1], &sixaxis, 1);
-	else if(style_set & HidNpadStyleTag_NpadJoyDual)
-	{
-		// For JoyDual, read from either the Left or Right Joy-Con depending on which is/are connected
-		u64 attrib = padGetAttributes(&padsState[0]);
-		if(attrib & HidNpadAttribute_IsLeftConnected)
-			hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[2], &sixaxis, 1);
-		else if(attrib & HidNpadAttribute_IsRightConnected)
-			hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[3], &sixaxis, 1);
-	}
+        hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[0], &sixaxis, 1);
+    else if (style_set & HidNpadStyleTag_NpadFullKey)
+        hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[1], &sixaxis, 1);
+    else if (style_set & HidNpadStyleTag_NpadJoyDual)
+    {
+        // For JoyDual, read from either the Left or Right Joy-Con depending on which is/are connected
+        u64 attrib = padGetAttributes(&padsState[0]);
+        if (attrib & HidNpadAttribute_IsLeftConnected)
+            hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[2], &sixaxis, 1);
+        else if (attrib & HidNpadAttribute_IsRightConnected)
+            hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[3], &sixaxis, 1);
+    }
 
-    SensorEvent accelState = SensorEvent { 0, SensorEventType::ACCEL, {-sixaxis.acceleration.x, -sixaxis.acceleration.z, sixaxis.acceleration.y}, 0 };
-    SensorEvent gyroState = SensorEvent { 0, SensorEventType::GYRO, {sixaxis.angular_velocity.x * 2.0f * M_PI, sixaxis.angular_velocity.z * 2.0f * M_PI, -sixaxis.angular_velocity.y * 2.0f * M_PI}, 0 };
+    auto accelState = SensorEvent{
+        0,
+        SensorEventType::ACCEL,
+        { -sixaxis.acceleration.x,
+          -sixaxis.acceleration.z,
+          sixaxis.acceleration.y
+        },
+        0
+    };
+    auto gyroState = SensorEvent{
+        0,
+        SensorEventType::GYRO,
+        { static_cast<float>(sixaxis.angular_velocity.x * 2.0f * M_PI),
+          static_cast<float>(sixaxis.angular_velocity.z * 2.0f * M_PI),
+          static_cast<float>(-sixaxis.angular_velocity.y * 2.0f * M_PI)
+        },
+        0 };
     getControllerSensorStateChanged()->fire(accelState);
     getControllerSensorStateChanged()->fire(gyroState);
     Application::setActiveEvent(true);
@@ -488,21 +499,21 @@ void SwitchInputManager::initCursor(NVGcontext* vg)
     }
 }
 
-BrlsKeyboardScancode SwitchInputManager::switchKeyToGlfwKey(int key)
+static BrlsKeyboardScancode hidKey2BrlsKey(int key)
 {
     if (KBD_A <= key && key <= KBD_Z)
     {
         return (BrlsKeyboardScancode)(key - KBD_A + BRLS_KBD_KEY_A);
     }
-    else if (KBD_1 <= key && key <= KBD_9)
+    if (KBD_1 <= key && key <= KBD_9)
     {
         return (BrlsKeyboardScancode)(key - KBD_1 + BRLS_KBD_KEY_1);
     }
-    else if (KBD_F1 <= key && key <= KBD_F12)
+    if (KBD_F1 <= key && key <= KBD_F12)
     {
         return (BrlsKeyboardScancode)(key - KBD_F1 + BRLS_KBD_KEY_F1);
     }
-    else if (KBD_KP1 <= key && key <= KBD_KP9)
+    if (KBD_KP1 <= key && key <= KBD_KP9)
     {
         return (BrlsKeyboardScancode)(key - KBD_KP1 + BRLS_KBD_KEY_KP_1);
     }
@@ -612,6 +623,21 @@ BrlsKeyboardScancode SwitchInputManager::switchKeyToGlfwKey(int key)
         // case KBD_HASHTILDE: return GLFW_HASHTILDE;
         default:
             return BRLS_KBD_KEY_UNKNOWN;
+    }
+}
+
+void SwitchInputManager::hidInitializeKeyboardMap()
+{
+    m_hid_brls_map[KBD_NONE]             = BRLS_KBD_KEY_UNKNOWN;
+    m_brls_hid_map[BRLS_KBD_KEY_UNKNOWN] = KBD_NONE;
+
+    for (int i = 0; i < 256; ++i)
+    {
+        const auto brlsKey = hidKey2BrlsKey(i);
+        if (brlsKey == BRLS_KBD_KEY_UNKNOWN)
+            continue;
+        m_hid_brls_map[i]       = brlsKey;
+        m_brls_hid_map[brlsKey] = i;
     }
 }
 

--- a/library/lib/platforms/switch/switch_input.cpp
+++ b/library/lib/platforms/switch/switch_input.cpp
@@ -252,6 +252,17 @@ void SwitchInputManager::updateControllerStateInner(ControllerState* state, PadS
     state->buttons[BUTTON_NAV_RIGHT] |= getKeyboardKeyState(BRLS_KBD_KEY_RIGHT);
     state->buttons[BUTTON_NAV_DOWN] |= getKeyboardKeyState(BRLS_KBD_KEY_DOWN);
     state->buttons[BUTTON_NAV_LEFT] |= getKeyboardKeyState(BRLS_KBD_KEY_LEFT);
+
+    if (Application::isSwapInputKeys())
+    {
+        state->buttons[BUTTON_B] |= getKeyboardKeyState(BRLS_KBD_KEY_ENTER);
+        state->buttons[BUTTON_A] |= getKeyboardKeyState(BRLS_KBD_KEY_ESCAPE);
+    }
+    else
+    {
+        state->buttons[BUTTON_A] |= getKeyboardKeyState(BRLS_KBD_KEY_ENTER);
+        state->buttons[BUTTON_B] |= getKeyboardKeyState(BRLS_KBD_KEY_ESCAPE);
+    }
 }
 
 bool SwitchInputManager::getKeyboardKeyState(BrlsKeyboardScancode key)

--- a/library/lib/views/edit_text_dialog.cpp
+++ b/library/lib/views/edit_text_dialog.cpp
@@ -99,27 +99,29 @@ namespace brls
                     });
                 return true; }, true);
 
-        keyEvent = Application::getPlatform()->getInputManager()->getKeyboardKeyStateChanged()->subscribe([this](const KeyState& state) {
-            if (!state.pressed) return;
-
-            switch (state.key) {
-                case BRLS_KBD_KEY_BACKSPACE:
-                case BRLS_KBD_KEY_DELETE: // This is to ensure that the delete operation of the PSV ime will not be ignored
-                    this->backspaceEvent.fire();
-                    break;
-                case BRLS_KBD_KEY_V:
+        // register paste action
+        int pasteKey = BRLS_KBD_MODIFIER_CTRL;
 #ifdef __APPLE__
-                    if (state.mods & (BRLS_KBD_MODIFIER_CTRL | BRLS_KBD_MODIFIER_META)) {
-#else
-                    if (state.mods & BRLS_KBD_MODIFIER_CTRL) {
+        pasteKey = BRLS_KBD_MODIFIER_META;
 #endif
-                        this->clipboardEvent.fire(Application::getPlatform()->pasteFromClipboard());
-                    }
-                    break;
-                default:
-                    break;
-            }
+        this->registerAction({ BRLS_KBD_KEY_V, pasteKey }, [this](...)
+        {
+            this->clipboardEvent.fire(Application::getPlatform()->pasteFromClipboard());
+            return true;
         });
+
+        // register delete action
+        this->registerAction({ BRLS_KBD_KEY_DELETE }, [this](...)
+        {
+            // This is to ensure that the delete operation of the PSV ime will not be ignored
+            this->backspaceEvent.fire();
+            return true;
+        }, true);
+        this->registerAction({ BRLS_KBD_KEY_BACKSPACE }, [this](...)
+        {
+            this->backspaceEvent.fire();
+            return true;
+        }, true);
 
         this->registerAction("hints/delete"_i18n, BUTTON_BACK, [this](...)
             {
@@ -155,10 +157,7 @@ namespace brls
         this->init = true;
     }
 
-    EditTextDialog::~EditTextDialog()
-    {
-        Application::getPlatform()->getInputManager()->getKeyboardKeyStateChanged()->unsubscribe(keyEvent);
-    }
+    EditTextDialog::~EditTextDialog() = default;
 
     void EditTextDialog::open()
     {

--- a/library/lib/views/hint.cpp
+++ b/library/lib/views/hint.cpp
@@ -53,23 +53,25 @@ const std::string hintXML = R"xml(
     </brls:Box>
 )xml";
 
-Hint::Hint(Action action, bool allowAButtonTouch)
+Hint::Hint(std::shared_ptr<Action> action, bool allowAButtonTouch)
     : Box(Axis::ROW)
-    , action(action)
+      , action(action)
 {
     this->inflateFromXMLString(hintXML);
     this->setFocusable(false);
 
-    icon->setText(getKeyIcon(action.button));
-    hint->setText(action.hintText);
+    icon->setText(getKeyIcon(static_cast<ControllerButton>(action->getButton())));
+    hint->setText(action->getHintText());
 
-    if ((action.button != BUTTON_A || allowAButtonTouch) && action.available && !Application::isInputBlocks())
+    if ((action->getButton() != BUTTON_A || allowAButtonTouch) && action->isAvailable() && !Application::isInputBlocks())
     {
         this->addGestureRecognizer(new TapGestureRecognizer(this, [this, action]()
-            { action.actionListener(this); }));
+        {
+            action->getActionListener()(this);
+        }));
     }
 
-    if (!action.available || Application::isInputBlocks())
+    if (!action->isAvailable() || Application::isInputBlocks())
     {
         Theme theme = Application::getTheme();
         icon->setTextColor(theme["brls/text_disabled"]);
@@ -127,20 +129,27 @@ Hints::Hints()
     setDirection(Direction::LEFT_TO_RIGHT);
 
     hintSubscription = Application::getGlobalHintsUpdateEvent()->subscribe([this]()
+    {
+        if (!AppletFrame::HIDE_BOTTOM_BAR || forceShown)
         {
-            if (!AppletFrame::HIDE_BOTTOM_BAR || forceShown)
-            {
-                refillHints(Application::getCurrentFocus());
-            } });
+            refillHints(Application::getCurrentFocus());
+        }
+    });
 
     this->registerBoolXMLAttribute("addBaseAction", [this](bool value)
-        { this->setAddUnableAButtonAction(value); });
+    {
+        this->setAddUnableAButtonAction(value);
+    });
 
     this->registerBoolXMLAttribute("allowAButtonTouch", [this](bool value)
-        { this->setAllowAButtonTouch(value); });
+    {
+        this->setAllowAButtonTouch(value);
+    });
 
     this->registerBoolXMLAttribute("forceShown", [this](bool value)
-        { this->forceShown = value; });
+    {
+        this->forceShown = value;
+    });
 }
 
 Hints::~Hints()
@@ -148,56 +157,15 @@ Hints::~Hints()
     Application::getGlobalHintsUpdateEvent()->unsubscribe(hintSubscription);
 }
 
-void Hints::refillHints(View* focusView)
+static int buttonToSortableVal(ControllerButton button)
 {
-    if (!focusView)
-        return;
-
-    // todo: 做一个缓存，可以节约 Hint 组件生成
-    clearViews();
-
-    std::set<ControllerButton> addedButtons; // we only ever want one action per key
-    std::vector<Action> actions;
-
-    while (focusView != nullptr)
-    {
-        for (auto& action : focusView->getActions())
-        {
-            if (action.hidden)
-                continue;
-
-            if (addedButtons.find(action.button) != addedButtons.end())
-                continue;
-
-            addedButtons.insert(action.button);
-            actions.push_back(action);
-        }
-
-        focusView = focusView->getParent();
-    }
-
-    if (addUnableAButtonAction && std::find(actions.begin(), actions.end(), BUTTON_A) == actions.end())
-    {
-        actions.push_back(Action { BUTTON_A, 0, "hints/ok"_i18n, false, false, false, Sound::SOUND_NONE, NULL });
-    }
-
-    // Sort the actions
-    std::stable_sort(actions.begin(), actions.end(), Hints::actionsSortFunc);
-
-    for (Action action : actions)
-    {
-        Hint* hint = new Hint(action, allowAButtonTouch);
-        addView(hint);
-    }
-}
-
-int buttonToSortableVal(ControllerButton button) {
     // From left to right:
     //  - first +
     //  - then all hints that are not B and A in original order
     //  - finally B and A
 
-    switch (button) {
+    switch (button)
+    {
         case BUTTON_START:
             return 0;
         case BUTTON_B:
@@ -209,9 +177,55 @@ int buttonToSortableVal(ControllerButton button) {
     }
 }
 
-bool Hints::actionsSortFunc(Action a, Action b)
+static bool actionsSortFunc(const std::shared_ptr<Action>& a, const std::shared_ptr<Action>& b)
 {
-    return buttonToSortableVal(a.button) < buttonToSortableVal(b.button);
+    return buttonToSortableVal(static_cast<ControllerButton>(a->getButton())) < buttonToSortableVal(static_cast<ControllerButton>(b->getButton()));
+}
+
+void Hints::refillHints(View* focusView)
+{
+    if (!focusView)
+        return;
+
+    // todo: 做一个缓存，可以节约 Hint 组件生成
+    clearViews();
+
+    std::set<ControllerButton> addedButtons; // we only ever want one action per key
+    std::vector<std::shared_ptr<Action> > actions;
+
+    while (focusView != nullptr)
+    {
+        for (auto& action : focusView->getActions())
+        {
+            if (action->getType() != ACTION_GAMEPAD)
+                continue; // only show gamepad actions in hints
+
+            if (action->isHidden())
+                continue;
+
+            if (addedButtons.find(static_cast<ControllerButton>(action->getButton())) != addedButtons.end())
+                continue;
+
+            addedButtons.insert(static_cast<ControllerButton>(action->getButton()));
+            actions.push_back(action);
+        }
+
+        focusView = focusView->getParent();
+    }
+
+    if (addUnableAButtonAction && getAction(BUTTON_A) == actions.end())
+    {
+        actions.push_back(std::make_shared<GamepadAction>(BUTTON_A, 0, "hints/ok"_i18n, false, false, false, Sound::SOUND_NONE, nullptr));
+    }
+
+    // Sort the actions
+    std::stable_sort(actions.begin(), actions.end(), actionsSortFunc);
+
+    for (auto action : actions)
+    {
+        Hint* hint = new Hint(action, allowAButtonTouch);
+        addView(hint);
+    }
 }
 
 View* Hints::create()

--- a/library/lib/views/hint.cpp
+++ b/library/lib/views/hint.cpp
@@ -206,6 +206,11 @@ void Hints::refillHints(View* focusView)
             if (addedButtons.find(static_cast<ControllerButton>(action->getButton())) != addedButtons.end())
                 continue;
 
+            if (Application::isHintsLiteMode() && action->getButton() != BUTTON_A && action->getButton() != BUTTON_B)
+            {
+                continue;
+            }
+
             addedButtons.insert(static_cast<ControllerButton>(action->getButton()));
             actions.push_back(action);
         }

--- a/library/lib/views/hint.cpp
+++ b/library/lib/views/hint.cpp
@@ -213,7 +213,12 @@ void Hints::refillHints(View* focusView)
         focusView = focusView->getParent();
     }
 
-    if (addUnableAButtonAction && getAction(BUTTON_A) == actions.end())
+    const auto it = std::find_if(actions.begin(), actions.end(), [](const std::shared_ptr<Action>& action)
+    {
+        return *action == BUTTON_A;
+    });
+
+    if (addUnableAButtonAction && it == actions.end())
     {
         actions.push_back(std::make_shared<GamepadAction>(BUTTON_A, 0, "hints/ok"_i18n, false, false, false, Sound::SOUND_NONE, nullptr));
     }


### PR DESCRIPTION
> [!WARNING]
> This PR changes the default behavior of borealis. If you need the desktop-related features, please pay attention to the instructions below.

Previously, it was simply a matter of binding some keyboard keys to controller buttons. This PR removes all key bindings except for the directional keys and A (Enter) and B (ESC), replacing them with new shortcut actions API.

```c++
// ctrl-f
registerAction({brls::BRLS_KBD_KEY_F, brls::BRLS_KBD_MODIFIER_CTRL}, [](...){
    return true;
});

// ctrl-shift-f1
registerAction({brls::BRLS_KBD_KEY_F1, brls::BRLS_KBD_MODIFIER_CTRL | brls::BRLS_KBD_MODIFIER_SHIFT}, [](...){
    return true;
});

// pageUp
registerAction({brls::BRLS_KBD_KEY_PAGE_UP}, [](...){
    return true;
});
```

Similar to the previous controller button bindings, the new desktop shortcuts support binding a shortcut to a callback function.