### PR TITLE
Fix error with gcc due to conflict of fmt with Apple headers

### DIFF
--- a/library/include/borealis/core/platform.hpp
+++ b/library/include/borealis/core/platform.hpp
@@ -19,7 +19,9 @@
 
 #include <borealis/core/audio.hpp>
 #include <borealis/core/font.hpp>
+#ifndef __OBJC__
 #include <borealis/core/i18n.hpp>
+#endif
 #include <borealis/core/ime.hpp>
 #include <borealis/core/input.hpp>
 #include <borealis/core/theme.hpp>
@@ -272,7 +274,9 @@ class Platform
     /**
      * App locale, empty for default
      */
+#ifndef __OBJC__
     static inline std::string APP_LOCALE_DEFAULT = LOCALE_AUTO;
+#endif
 };
 
 } // namespace brls

--- a/library/lib/platforms/desktop/desktop_darwin.mm
+++ b/library/lib/platforms/desktop/desktop_darwin.mm
@@ -15,7 +15,6 @@
     limitations under the License.
 */
 
-#import <borealis/core/logger.hpp>
 #import <borealis/platforms/desktop/desktop_platform.hpp>
 #import <CoreWLAN/CoreWLAN.h>
 


### PR DESCRIPTION
Pulling in `libfmt` headers into `desktop_darwin.mm` breaks build with gcc, since `id` is a reserved keyword, and hell breaks loose:
```
In file included from /opt/local/include/libfmt11/fmt/format.h:41,
                 from /opt/local/include/libfmt11/fmt/core.h:5,
                 from /opt/local/var/macports/build/wiliwili-3c0fad08/work/wiliwili-1.5.2/library/borealis/library/include/borealis/core/logger.hpp:33,
                 from /opt/local/var/macports/build/wiliwili-3c0fad08/work/wiliwili-1.5.2/library/borealis/library/lib/platforms/desktop/[desktop_darwin.mm:18](http://desktop_darwin.mm:18/):
/opt/local/include/libfmt11/fmt/base.h: In member function 'constexpr int fmt::v11::detail::compile_parse_context<Char>::next_arg_id()':
/opt/local/include/libfmt11/fmt/base.h:1245:12: error: expected unqualified-id before '>=' token
 1245 |     if (id >= num_args_) report_error("argument not found");
      |            ^~
/opt/local/include/libfmt11/fmt/base.h: In member function 'constexpr void fmt::v11::detail::compile_parse_context<Char>::check_arg_id(int)':
/opt/local/include/libfmt11/fmt/base.h:1251:12: error: expected unqualified-id before '>=' token
 1251 |     if (id >= num_args_) report_error("argument not found");
      |            ^~
/opt/local/include/libfmt11/fmt/base.h: In member function 'constexpr const Char* fmt::v11::detail::format_string_checker<Char, NUM_ARGS, NUM_NAMED_ARGS, DYNAMIC_NAMES>::on_format_specs(int, const Char*, const Char*)':
/opt/local/include/libfmt11/fmt/base.h:1725:12: error: expected unqualified-id before '>=' token
 1725 |     if (id >= 0 && id < NUM_ARGS) return parse_funcs_[id](context_);
      |            ^~
/opt/local/include/libfmt11/fmt/base.h: In member function 'constexpr fmt::v11::basic_format_args<Context>::format_arg fmt::v11::basic_format_args<Context>::get(int) const':
/opt/local/include/libfmt11/fmt/base.h:2621:16: error: cannot find protocol declaration for 'max_size'
 2621 |       if (id < max_size()) arg = args_[id];
      |                ^~~~~~~~
/opt/local/include/libfmt11/fmt/base.h:2621:16: error: cannot find protocol declaration for 'max_size'
```
Excluding `libfmt` stuff from `logger.hpp` appears problematic, it is easier to get rid of `logger.hpp` here, it is unneeded anyway. And make sure it is not pulled in transitively.