### PR TITLE
desktop_platform.cpp: fix crash on launch

### DIFF
--- a/library/lib/platforms/desktop/desktop_platform.cpp
+++ b/library/lib/platforms/desktop/desktop_platform.cpp
@@ -554,6 +554,8 @@ bool DesktopPlatform::hasEthernetConnection()
     if (globalRef)
     {
         CFDictionaryGetValueIfPresent(globalRef, kSCDynamicStorePropNetPrimaryInterface, &primaryIf);
+            if (primaryIf)
+                CFRetain(primaryIf);
         CFRelease(globalRef);
     }
     CFRelease(storeRef);
@@ -577,6 +579,7 @@ bool DesktopPlatform::hasEthernetConnection()
         }
         CFRelease(iflist);
     }
+    CFRelease(primaryIf);
 #elif defined(_WIN32)
     PIP_ADAPTER_ADDRESSES addrs = nullptr;
     ULONG outlen = sizeof(IP_ADAPTER_ADDRESSES), ret = 0, curindex = 0;


### PR DESCRIPTION
@xfangfang Fix for this:
```
Program received signal EXC_BAD_ACCESS, Could not access memory.
Reason: KERN_INVALID_ADDRESS at address: 0x4c696272
[Switching to process 11513 thread 0x2803]
0x92bd91c0 in objc_msgSend ()
(gdb) bt
#0  0x92bd91c0 in objc_msgSend ()
#1  0x919e1218 in CFEqual ()
#2  0x00318ce8 in brls::DesktopPlatform::hasEthernetConnection ()
#3  0x003932f0 in _ZNSt17_Function_handlerIFvvEZN4brls14WirelessWidget11updateStateEvEUlvE_E9_M_invokeERKSt9_Any_data ()
#4  0x0033dec4 in brls::Threading::task_loop ()
#5  0x90e36ec4 in _pthread_start ()
```