### PR TITLE
Get sensor data from right Joy-Con on JoyDual mode first

### DIFF
--- a/library/lib/platforms/switch/switch_input.cpp
+++ b/library/lib/platforms/switch/switch_input.cpp
@@ -438,10 +438,10 @@ void SwitchInputManager::handleControllerSensors()
     {
         // For JoyDual, read from either the Left or Right Joy-Con depending on which is/are connected
         u64 attrib = padGetAttributes(&padsState[0]);
-        if (attrib & HidNpadAttribute_IsLeftConnected)
-            hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[2], &sixaxis, 1);
-        else if (attrib & HidNpadAttribute_IsRightConnected)
+        if (attrib & HidNpadAttribute_IsRightConnected)
             hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[3], &sixaxis, 1);
+        else if (attrib & HidNpadAttribute_IsLeftConnected)
+            hidGetSixAxisSensorStates(this->m_six_axis_sensor_handle[2], &sixaxis, 1);
     }
 
     auto accelState = SensorEvent{


### PR DESCRIPTION
I strongly recommend to change the order of which Joy-Con the library should use sensor data from in JoyDual mode. This will almost always be preferred to be the right Joy-Con most of the time.