### PR TITLE
feat(glfw): set Wayland app_id / X11 WM_CLASS via Application::setAppId

### DIFF
--- a/library/include/borealis/core/application.hpp
+++ b/library/include/borealis/core/application.hpp
@@ -30,6 +30,8 @@
 #include <borealis/core/notification_manager.hpp>
 #include <borealis/views/label.hpp>
 #include <deque>
+#include <string>
+#include <utility>
 #include <vector>
 
 #ifdef __WINRT__
@@ -61,12 +63,23 @@ class Application
 
     static inline uint32_t ORIGINAL_WINDOW_WIDTH  = 1280;
     static inline uint32_t ORIGINAL_WINDOW_HEIGHT = 720;
+    inline static std::string appId = "";
 
     /**
      * Inits the borealis application.
      * Returns true if it succeeded, false otherwise.
      */
     static bool init();
+
+    /**
+     * Sets the application ID reported to the windowing system
+     * (Wayland app_id / X11 WM_CLASS). Desktop environments use it to
+     * associate the window with its .desktop entry, which is required
+     * for showing the correct icon in the taskbar.
+     * Must be called before createWindow().
+     */
+    static void setAppId(std::string appId) { Application::appId = std::move(appId); }
+    static const std::string& getAppId() { return Application::appId; }
 
     /**
      * Creates the application window with the given title.

--- a/library/lib/platforms/glfw/glfw_video.cpp
+++ b/library/lib/platforms/glfw/glfw_video.cpp
@@ -244,10 +244,17 @@ GLFWVideoContext::GLFWVideoContext(const std::string& windowTitle, uint32_t wind
     const std::string& appId = Application::getAppId();
     if (!appId.empty())
     {
-        glfwWindowHint(GLFW_WAYLAND_APP_ID, appId.c_str());
-        glfwWindowHint(GLFW_X11_CLASS_NAME, appId.c_str());
-        glfwWindowHint(GLFW_X11_INSTANCE_NAME, appId.c_str());
+#ifdef GLFW_WAYLAND_APP_ID
+        glfwWindowHintString(GLFW_WAYLAND_APP_ID, appId.c_str());
+#endif
+#ifdef GLFW_X11_CLASS_NAME
+        glfwWindowHintString(GLFW_X11_CLASS_NAME, appId.c_str());
+#endif
+#ifdef GLFW_X11_INSTANCE_NAME
+        glfwWindowHintString(GLFW_X11_INSTANCE_NAME, appId.c_str());
+#endif
     }
+#endif
 
 // create window
 #if defined(__linux__) || defined(_WIN32) || defined(__APPLE__)

--- a/library/lib/platforms/glfw/glfw_video.cpp
+++ b/library/lib/platforms/glfw/glfw_video.cpp
@@ -238,6 +238,16 @@ GLFWVideoContext::GLFWVideoContext(const std::string& windowTitle, uint32_t wind
     glfwWindowHint(GLFW_AUTO_ICONIFY, 0);
     glfwWindowHint(GLFW_SOFT_FULLSCREEN, 1);
 #endif
+#if defined(__linux__) || defined(_WIN32) || defined(__APPLE__)
+    // Set the application ID so desktop environments can match this window to its
+    // .desktop entry (Wayland app_id / X11 WM_CLASS) — required for taskbar icons.
+    const std::string& appId = Application::getAppId();
+    if (!appId.empty())
+    {
+        glfwWindowHint(GLFW_WAYLAND_APP_ID, appId.c_str());
+        glfwWindowHint(GLFW_X11_CLASS_NAME, appId.c_str());
+        glfwWindowHint(GLFW_X11_INSTANCE_NAME, appId.c_str());
+    }
 
 // create window
 #if defined(__linux__) || defined(_WIN32) || defined(__APPLE__)


### PR DESCRIPTION
## Problem

On Wayland, wiliwili's window reports an **empty app_id** (verified via KWin: `resourceClass=""`), so desktop environments like KDE Plasma cannot match the window to its `.desktop` entry. Result: the window shows **no icon** in the icon-only taskbar.

Root cause: the bundled GLFW only sends `xdg_toplevel_set_app_id` when the `GLFW_WAYLAND_APP_ID` hint is set (see xfangfang/glfw `wl_window.c`), and borealis never sets it.

## Fix

Add a small `Application::setAppId()` API (call it before `createWindow()`) and apply it via:

- `GLFW_WAYLAND_APP_ID` (Wayland app_id)
- `GLFW_X11_CLASS_NAME` / `GLFW_X11_INSTANCE_NAME` (X11 WM_CLASS)

Only affects the GLFW desktop backend; no-op when the app id is empty. Other platforms are untouched.

Companion PR in wiliwili will call `brls::Application::setAppId("cn.xfangfang.wiliwili")`. Follow-up issue: xfangfang/wiliwili (taskbar icon).