### PR TITLE
switch: fall back to shared font when custom font fails to load

### DIFF
--- a/library/lib/platforms/switch/switch_font.cpp
+++ b/library/lib/platforms/switch/switch_font.cpp
@@ -41,14 +41,21 @@ void SwitchFontLoader::loadFonts()
 
     // Simplified Chinese
     // custom Font
+    bool loadedCustomFont = false;
     if (access(USER_FONT_PATH.c_str(), F_OK) != -1)
     {
         brls::Logger::info("Load custom font: {}", USER_FONT_PATH);
-        this->loadFontFromFile(FONT_CHINESE_SIMPLIFIED, USER_FONT_PATH);
+        loadedCustomFont = this->loadFontFromFile(FONT_CHINESE_SIMPLIFIED, USER_FONT_PATH);
+        if (!loadedCustomFont)
+            Logger::error("switch: custom font {} existed but failed to load, falling back to the shared Chinese Simplified font", USER_FONT_PATH);
     }
     else
     {
         brls::Logger::warning("Cannot find custom font, (Searched at: {})", USER_FONT_PATH);
+    }
+
+    if (!loadedCustomFont)
+    {
         rc = plGetSharedFontByType(&font, PlSharedFontType_ChineseSimplified);
         if (R_SUCCEEDED(rc) && Application::loadFontFromMemory(FONT_CHINESE_SIMPLIFIED, font.address, font.size, false))
             nvgAddFallbackFontId(vg, Application::getFont(FONT_CHINESE_SIMPLIFIED), Application::getFont(FONT_REGULAR));


### PR DESCRIPTION
## Problem

When a custom font file exists at `USER_FONT_PATH` (e.g. `/config/tsvitch/font.ttf`) but fails to load (for example because it is empty or partially copied), `SwitchFontLoader::loadFonts()` silently ignores the return value of `loadFontFromFile()`. Since on Switch `Application::getDefaultFont()` returns `FONT_CHINESE_SIMPLIFIED`, an invalid font handle there means **no text renders at all** — the whole UI appears blank.

## Fix

Capture the result of `loadFontFromFile(FONT_CHINESE_SIMPLIFIED, ...)`. If the custom font is missing *or* fails to load, fall back to the system shared Chinese Simplified font (which is what happened before when no custom font existed), so text is always rendered.

Reported and tested on Nintendo Switch with the TsVitch app.